### PR TITLE
Support partial fulfillment of reduce-only orders

### DIFF
--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -579,17 +579,15 @@ func (db *InMemoryDatabase) getReduceOnlyOrderDisplay(order *LimitOrder) *LimitO
 		if position.Size.Sign() == order.BaseAssetQuantity.Sign() {
 			return nil
 		}
-		if position.Size.CmpAbs(order.GetUnFilledBaseAssetQuantity()) == 1 {
+		if position.Size.CmpAbs(order.GetUnFilledBaseAssetQuantity()) >= 0 {
 			// position is bigger than unfilled order size
 			orderCopy := deepCopyOrder(order)
 			return &orderCopy
 		} else {
 			// position is smaller than unfilled order
-			// display only the position size
+			// increase the filled quantity so that unfilled amount is equal to position size
 			orderCopy := deepCopyOrder(order)
-			orderCopy.BaseAssetQuantity = big.NewInt(0).Set(position.Size)
-			orderCopy.BaseAssetQuantity = orderCopy.BaseAssetQuantity.Neg(orderCopy.BaseAssetQuantity)
-			orderCopy.FilledBaseAssetQuantity = big.NewInt(0)
+			orderCopy.FilledBaseAssetQuantity = big.NewInt(0).Add(orderCopy.BaseAssetQuantity, position.Size) // both have opposite sign, therefore we add
 			return &orderCopy
 		}
 	} else {

--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -576,7 +576,7 @@ func (db *InMemoryDatabase) getReduceOnlyOrderDisplay(order *LimitOrder) *LimitO
 	positions := db.TraderMap[trader].Positions
 	if position, ok := positions[order.Market]; ok {
 		// position.Size, order.BaseAssetQuantity need to be of opposite sign and abs(position.Size) >= abs(order.BaseAssetQuantity)
-		if position.Size.Sign() == order.BaseAssetQuantity.Sign() {
+		if position.Size.Sign() == 0 || position.Size.Sign() == order.BaseAssetQuantity.Sign() {
 			return nil
 		}
 		if position.Size.CmpAbs(order.GetUnFilledBaseAssetQuantity()) >= 0 {

--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -254,7 +254,7 @@ func (db *InMemoryDatabase) GetAllOrders() []LimitOrder {
 
 	allOrders := []LimitOrder{}
 	for _, order := range db.OrderMap {
-		allOrders = append(allOrders, deepCopyOrder(*order))
+		allOrders = append(allOrders, deepCopyOrder(order))
 	}
 	return allOrders
 }
@@ -320,10 +320,14 @@ func (db *InMemoryDatabase) GetLongOrders(market Market, cutoff *big.Int) []Limi
 		if order.PositionType == LONG &&
 			order.Market == market &&
 			order.getOrderStatus().Status == Placed &&
-			(cutoff == nil || order.Price.Cmp(cutoff) <= 0) &&
-			// this will filter orders that are reduce only but with size > current position size (basically no partial fills) - @todo: think if this is correct
-			(!order.ReduceOnly || db.willReducePosition(order)) {
-			longOrders = append(longOrders, deepCopyOrder(*order))
+			(cutoff == nil || order.Price.Cmp(cutoff) <= 0) {
+			if order.ReduceOnly {
+				if reduceOnlyOrder := db.getReduceOnlyOrderDisplay(order); reduceOnlyOrder != nil {
+					longOrders = append(longOrders, *reduceOnlyOrder)
+				}
+			} else {
+				longOrders = append(longOrders, deepCopyOrder(order))
+			}
 		}
 	}
 	sortLongOrders(longOrders)
@@ -339,10 +343,14 @@ func (db *InMemoryDatabase) GetShortOrders(market Market, cutoff *big.Int) []Lim
 		if order.PositionType == SHORT &&
 			order.Market == market &&
 			order.getOrderStatus().Status == Placed &&
-			(cutoff == nil || order.Price.Cmp(cutoff) >= 0) &&
-			// this will filter orders that are reduce only but with size > current position size (basically no partial fills) - @todo: think if this is correct
-			(!order.ReduceOnly || db.willReducePosition(order)) {
-			shortOrders = append(shortOrders, deepCopyOrder(*order))
+			(cutoff == nil || order.Price.Cmp(cutoff) >= 0) {
+			if order.ReduceOnly {
+				if reduceOnlyOrder := db.getReduceOnlyOrderDisplay(order); reduceOnlyOrder != nil {
+					shortOrders = append(shortOrders, *reduceOnlyOrder)
+				}
+			} else {
+				shortOrders = append(shortOrders, deepCopyOrder(order))
+			}
 		}
 	}
 	sortShortOrders(shortOrders)
@@ -554,23 +562,38 @@ func (db *InMemoryDatabase) getTraderOrders(trader common.Address) []LimitOrder 
 	traderOrders := []LimitOrder{}
 	for _, order := range db.OrderMap {
 		if strings.EqualFold(order.UserAddress, trader.String()) {
-			traderOrders = append(traderOrders, deepCopyOrder(*order))
+			traderOrders = append(traderOrders, deepCopyOrder(order))
 		}
 	}
 	return traderOrders
 }
 
-func (db *InMemoryDatabase) willReducePosition(order *LimitOrder) bool {
+func (db *InMemoryDatabase) getReduceOnlyOrderDisplay(order *LimitOrder) *LimitOrder {
 	trader := common.HexToAddress(order.UserAddress)
 	if db.TraderMap[trader] == nil {
-		return false
+		return nil
 	}
 	positions := db.TraderMap[trader].Positions
 	if position, ok := positions[order.Market]; ok {
 		// position.Size, order.BaseAssetQuantity need to be of opposite sign and abs(position.Size) >= abs(order.BaseAssetQuantity)
-		return position.Size.Sign() != order.BaseAssetQuantity.Sign() && big.NewInt(0).Abs(position.Size).Cmp(big.NewInt(0).Abs(order.BaseAssetQuantity)) != -1
+		if position.Size.Sign() == order.BaseAssetQuantity.Sign() {
+			return nil
+		}
+		if position.Size.CmpAbs(order.GetUnFilledBaseAssetQuantity()) == 1 {
+			// position is bigger than unfilled order size
+			orderCopy := deepCopyOrder(order)
+			return &orderCopy
+		} else {
+			// position is smaller than unfilled order
+			// display only the position size
+			orderCopy := deepCopyOrder(order)
+			orderCopy.BaseAssetQuantity = big.NewInt(0).Set(position.Size)
+			orderCopy.BaseAssetQuantity = orderCopy.BaseAssetQuantity.Neg(orderCopy.BaseAssetQuantity)
+			orderCopy.FilledBaseAssetQuantity = big.NewInt(0)
+			return &orderCopy
+		}
 	} else {
-		return false
+		return nil
 	}
 }
 
@@ -658,7 +681,7 @@ func getAvailableMargin(trader *Trader, pendingFunding *big.Int, oraclePrices ma
 }
 
 // deepCopyOrder deep copies the LimitOrder struct
-func deepCopyOrder(order LimitOrder) LimitOrder {
+func deepCopyOrder(order *LimitOrder) LimitOrder {
 	lifecycleList := &order.LifecycleList
 	return LimitOrder{
 		Id:                      order.Id,

--- a/plugin/evm/limitorders/memory_database_test.go
+++ b/plugin/evm/limitorders/memory_database_test.go
@@ -102,7 +102,7 @@ func TestGetShortOrders(t *testing.T) {
 	shortOrder3, orderId := createLimitOrder(SHORT, userAddress, baseAssetQuantity, price3, status, signature3, blockNumber3, salt3)
 	inMemoryDatabase.Add(orderId, &shortOrder3)
 
-	//Short order with price 9.01 and blockNumber 3
+	//Reduce only short order with price 9 and blockNumber 4
 	id4 := uint64(4)
 	signature4 := []byte(fmt.Sprintf("Signature short order is %d", id4))
 	price4 := big.NewInt(9)
@@ -132,20 +132,21 @@ func TestGetShortOrders(t *testing.T) {
 
 	// now test with one reduceOnly order when there's a long position
 
-	size := big.NewInt(0).Mul(big.NewInt(10), _1e18)
+	size := big.NewInt(0).Mul(big.NewInt(2), _1e18)
 	inMemoryDatabase.UpdatePosition(trader, market, size, big.NewInt(0).Mul(big.NewInt(100), _1e6), false)
 
 	returnedShortOrders = inMemoryDatabase.GetShortOrders(market, nil)
 	assert.Equal(t, 4, len(returnedShortOrders))
 
 	// at least one of the orders should be reduce only
-	reduceOnlyOrderCount := 0
+	reduceOnlyOrder := LimitOrder{}
 	for _, order := range returnedShortOrders {
 		if order.ReduceOnly {
-			reduceOnlyOrderCount += 1
+			reduceOnlyOrder = order
 		}
 	}
-	assert.Equal(t, 1, reduceOnlyOrderCount)
+	assert.Equal(t, reduceOnlyOrder.Salt, salt4)
+	assert.Equal(t, reduceOnlyOrder.BaseAssetQuantity, big.NewInt(0).Neg(size))
 }
 
 func TestGetLongOrders(t *testing.T) {

--- a/plugin/evm/limitorders/memory_database_test.go
+++ b/plugin/evm/limitorders/memory_database_test.go
@@ -146,7 +146,8 @@ func TestGetShortOrders(t *testing.T) {
 		}
 	}
 	assert.Equal(t, reduceOnlyOrder.Salt, salt4)
-	assert.Equal(t, reduceOnlyOrder.BaseAssetQuantity, big.NewInt(0).Neg(size))
+	assert.Equal(t, reduceOnlyOrder.BaseAssetQuantity, baseAssetQuantity)
+	assert.Equal(t, reduceOnlyOrder.FilledBaseAssetQuantity, big.NewInt(0).Neg(_1e18))
 }
 
 func TestGetLongOrders(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged
Supports partial fills of reduce-only orders. If user position is +10 ETH, then a 15 ETH reduce-only short order will be shown as -10 ETH in the orderbook and to the matching engine.

## How this works
Reduce-only order is deep-copied and quantity is set as current position size

## How this was tested
Unit tests
