### PR TITLE
Retry Failed Orders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
         shell: bash
       - run: ./scripts/build_test.sh -race
         shell: bash
-      - run: go test github.com/ava-labs/subnet-evm/precompile/contracts/hubblebibliophile
-        shell: bash
       - run: ./scripts/coverage.sh
         shell: bash
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - '*'
-      
+
     tags:
       - "*"
   # pull_request:
@@ -24,5 +24,7 @@ jobs:
           go-version: ${{ matrix.go }}
       - run: go mod download
         shell: bash
-      - run:  go test ./plugin/evm/... -test.v 
+      - run:  go test ./plugin/evm/... -test.v
+        shell: bash
+      - run: go test github.com/ava-labs/subnet-evm/precompile/contracts/bibliophile
         shell: bash

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -120,7 +120,7 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
 }
 
 func (lop *limitOrderProcesser) RunBuildBlockPipeline() {
-	lop.buildBlockPipeline.Run()
+	lop.buildBlockPipeline.Run(new(big.Int).Add(lop.blockChain.CurrentBlock().Number(), big.NewInt(1)))
 }
 
 func (lop *limitOrderProcesser) GetOrderBookAPI() *limitorders.OrderBookAPI {

--- a/plugin/evm/limitorders/build_block_pipeline.go
+++ b/plugin/evm/limitorders/build_block_pipeline.go
@@ -23,7 +23,7 @@ func NewBuildBlockPipeline(db LimitOrderDatabase, lotp LimitOrderTxProcessor, co
 	}
 }
 
-func (pipeline *BuildBlockPipeline) Run() {
+func (pipeline *BuildBlockPipeline) Run(blockNumber *big.Int) {
 	markets := pipeline.GetActiveMarkets()
 
 	if len(markets) == 0 {
@@ -48,7 +48,7 @@ func (pipeline *BuildBlockPipeline) Run() {
 	cancellableOrderIds := pipeline.cancelOrders(ordersToCancel)
 	orderMap := make(map[Market]*Orders)
 	for _, market := range markets {
-		orderMap[market] = pipeline.fetchOrders(market, underlyingPrices[market], cancellableOrderIds)
+		orderMap[market] = pipeline.fetchOrders(market, underlyingPrices[market], cancellableOrderIds, blockNumber)
 	}
 	pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices)
 	for _, market := range markets {
@@ -105,18 +105,18 @@ func (pipeline *BuildBlockPipeline) cancelOrders(cancellableOrders map[common.Ad
 	return cancellableOrderIds
 }
 
-func (pipeline *BuildBlockPipeline) fetchOrders(market Market, underlyingPrice *big.Int, cancellableOrderIds map[common.Hash]struct{}) *Orders {
+func (pipeline *BuildBlockPipeline) fetchOrders(market Market, underlyingPrice *big.Int, cancellableOrderIds map[common.Hash]struct{}, blockNumber *big.Int) *Orders {
 	_, lowerBoundForLongs := pipeline.configService.GetAcceptableBounds(market)
 	// any long orders below the permissible lowerbound are irrelevant, because they won't be matched no matter what.
 	// this assumes that all above cancelOrder transactions got executed successfully (or atleast they are not meant to be executed anyway if they passed the cancellation criteria)
-	longOrders := removeOrdersWithIds(pipeline.db.GetLongOrders(market, lowerBoundForLongs), cancellableOrderIds)
+	longOrders := removeOrdersWithIds(pipeline.db.GetLongOrders(market, lowerBoundForLongs, blockNumber), cancellableOrderIds)
 
 	upperBoundforShorts, _ := pipeline.configService.GetAcceptableBoundsForLiquidation(market)
 	if len(longOrders) > 0 {
 		upperBoundforShorts = utils.BigIntMax(longOrders[0].Price, upperBoundforShorts)
 	}
 	// while longOrders[0].Price would have been enough for the matching engine alone, but we include orders within the allowable liqupperbound, to allow for liquidations to happen
-	shortOrders := removeOrdersWithIds(pipeline.db.GetShortOrders(market, upperBoundforShorts), cancellableOrderIds)
+	shortOrders := removeOrdersWithIds(pipeline.db.GetShortOrders(market, upperBoundforShorts, blockNumber), cancellableOrderIds)
 	return &Orders{longOrders, shortOrders}
 }
 

--- a/plugin/evm/limitorders/contract_events_processor.go
+++ b/plugin/evm/limitorders/contract_events_processor.go
@@ -194,9 +194,16 @@ func (cep *ContractEventsProcessor) handleOrderBookEvent(event *types.Log) {
 		orderId := event.Topics[1]
 		if !removed {
 			log.Info("OrderMatchingError", "args", args, "orderId", orderId.String())
-			if err := cep.database.SetOrderStatus(orderId, Execution_Failed, event.BlockNumber); err != nil {
-				log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
-				return
+			if args["err"].(string) == "CH: Below Minimum Allowable Margin" {
+				if err := cep.database.SetOrderStatus(orderId, Below_Minimum_Allowable_Margin, event.BlockNumber); err != nil {
+					log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
+					return
+				}
+			} else {
+				if err := cep.database.SetOrderStatus(orderId, Execution_Failed, event.BlockNumber); err != nil {
+					log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
+					return
+				}
 			}
 		} else {
 			log.Info("OrderMatchingError removed", "args", args, "orderId", orderId.String(), "number", event.BlockNumber)

--- a/plugin/evm/limitorders/contract_events_processor.go
+++ b/plugin/evm/limitorders/contract_events_processor.go
@@ -138,7 +138,7 @@ func (cep *ContractEventsProcessor) handleOrderBookEvent(event *types.Log) {
 		orderId := event.Topics[2]
 		log.Info("OrderCancelled", "orderId", orderId.String(), "removed", removed)
 		if !removed {
-			if err := cep.database.SetOrderStatus(orderId, Cancelled, event.BlockNumber); err != nil {
+			if err := cep.database.SetOrderStatus(orderId, Cancelled, "", event.BlockNumber); err != nil {
 				log.Error("error in SetOrderStatus", "method", "OrderCancelled", "err", err)
 				return
 			}
@@ -194,16 +194,9 @@ func (cep *ContractEventsProcessor) handleOrderBookEvent(event *types.Log) {
 		orderId := event.Topics[1]
 		if !removed {
 			log.Info("OrderMatchingError", "args", args, "orderId", orderId.String())
-			if args["err"].(string) == "CH: Below Minimum Allowable Margin" {
-				if err := cep.database.SetOrderStatus(orderId, Below_Minimum_Allowable_Margin, event.BlockNumber); err != nil {
-					log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
-					return
-				}
-			} else {
-				if err := cep.database.SetOrderStatus(orderId, Execution_Failed, event.BlockNumber); err != nil {
-					log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
-					return
-				}
+			if err := cep.database.SetOrderStatus(orderId, Execution_Failed, args["err"].(string), event.BlockNumber); err != nil {
+				log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
+				return
 			}
 		} else {
 			log.Info("OrderMatchingError removed", "args", args, "orderId", orderId.String(), "number", event.BlockNumber)

--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -39,8 +39,14 @@ func NewInMemoryDatabase(configService IConfigService) *InMemoryDatabase {
 	}
 }
 
-var _1e18 = big.NewInt(1e18)
-var _1e6 = big.NewInt(1e6)
+var (
+	_1e18 = big.NewInt(1e18)
+	_1e6  = big.NewInt(1e6)
+)
+
+const (
+	RETRY_AFTER_BLOCKS = 10
+)
 
 type Collateral int
 
@@ -375,12 +381,12 @@ func (db *InMemoryDatabase) getCleanOrder(order *LimitOrder, blockNumber *big.In
 		// 4. We might have made margin requirements for order fulfillment more liberal at a later stage
 		// Hence, in view of the above and to serve as a catch-all we retry failed orders after every 100 blocks
 		// Note at if an order is failing multiple times and it is also not being caught in the auto-cancel logic, then something/somewhere definitely needs fixing
-		if blockNumber != nil && orderStatus.BlockNumber+100 <= blockNumber.Uint64() {
+		if blockNumber != nil && orderStatus.BlockNumber+RETRY_AFTER_BLOCKS <= blockNumber.Uint64() {
 			eligibleForExecution = true
 		} else {
 			if blockNumber.Uint64()%10 == 0 {
 				// to not make the log too noisy
-				log.Warn("eligible order is in Execution_Failed state", "orderId", order.String(), "retryInBlocks", orderStatus.BlockNumber+100-blockNumber.Uint64())
+				log.Warn("eligible order is in Execution_Failed state", "orderId", order.String(), "retryInBlocks", orderStatus.BlockNumber+RETRY_AFTER_BLOCKS-blockNumber.Uint64())
 			}
 		}
 	}

--- a/plugin/evm/limitorders/memory_database.go
+++ b/plugin/evm/limitorders/memory_database.go
@@ -242,7 +242,7 @@ func (db *InMemoryDatabase) SetOrderStatus(orderId common.Hash, status Status, i
 	defer db.mu.Unlock()
 
 	if db.OrderMap[orderId] == nil {
-		return fmt.Errorf("Invalid orderId %s", orderId.Hex())
+		return fmt.Errorf("nvalid orderId %s", orderId.Hex())
 	}
 	db.OrderMap[orderId].LifecycleList = append(db.OrderMap[orderId].LifecycleList, Lifecycle{blockNumber, status, info})
 	return nil
@@ -378,7 +378,10 @@ func (db *InMemoryDatabase) getCleanOrder(order *LimitOrder, blockNumber *big.In
 		if blockNumber != nil && orderStatus.BlockNumber+100 <= blockNumber.Uint64() {
 			eligibleForExecution = true
 		} else {
-			log.Warn("eligible order is in Execution_Failed state", "orderId", order.String(), "retryInBlocks", orderStatus.BlockNumber+100-blockNumber.Uint64())
+			if blockNumber.Uint64()%10 == 0 {
+				// to not make the log too noisy
+				log.Warn("eligible order is in Execution_Failed state", "orderId", order.String(), "retryInBlocks", orderStatus.BlockNumber+100-blockNumber.Uint64())
+			}
 		}
 	}
 

--- a/plugin/evm/limitorders/memory_database_test.go
+++ b/plugin/evm/limitorders/memory_database_test.go
@@ -434,7 +434,7 @@ func TestAccept(t *testing.T) {
 		orderId1 := addLimitOrder(inMemoryDatabase)
 		orderId2 := addLimitOrder(inMemoryDatabase)
 
-		err := inMemoryDatabase.SetOrderStatus(orderId1, FulFilled, 51)
+		err := inMemoryDatabase.SetOrderStatus(orderId1, FulFilled, "", 51)
 		assert.Nil(t, err)
 		assert.Equal(t, inMemoryDatabase.OrderMap[orderId1].getOrderStatus().Status, FulFilled)
 
@@ -451,7 +451,7 @@ func TestAccept(t *testing.T) {
 	t.Run("Order is fulfilled, should be deleted when a future block is accepted", func(t *testing.T) {
 		inMemoryDatabase := getDatabase()
 		orderId := addLimitOrder(inMemoryDatabase)
-		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, 51)
+		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, "", 51)
 		assert.Nil(t, err)
 		assert.Equal(t, inMemoryDatabase.OrderMap[orderId].getOrderStatus().Status, FulFilled)
 
@@ -464,7 +464,7 @@ func TestAccept(t *testing.T) {
 	t.Run("Order is fulfilled, should not be deleted when a past block is accepted", func(t *testing.T) {
 		inMemoryDatabase := getDatabase()
 		orderId := addLimitOrder(inMemoryDatabase)
-		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, 51)
+		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, "", 51)
 		assert.Nil(t, err)
 		assert.Equal(t, inMemoryDatabase.OrderMap[orderId].getOrderStatus().Status, FulFilled)
 
@@ -506,7 +506,7 @@ func TestRevertLastStatus(t *testing.T) {
 	t.Run("revert status for fulfilled order", func(t *testing.T) {
 		inMemoryDatabase := getDatabase()
 		orderId := addLimitOrder(inMemoryDatabase)
-		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, 3)
+		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, "", 3)
 		assert.Nil(t, err)
 
 		err = inMemoryDatabase.RevertLastStatus(orderId)
@@ -519,7 +519,7 @@ func TestRevertLastStatus(t *testing.T) {
 	t.Run("revert status for accepted + fulfilled order - expect error", func(t *testing.T) {
 		inMemoryDatabase := getDatabase()
 		orderId := addLimitOrder(inMemoryDatabase)
-		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, 3)
+		err := inMemoryDatabase.SetOrderStatus(orderId, FulFilled, "", 3)
 		assert.Nil(t, err)
 
 		inMemoryDatabase.Accept(3)

--- a/plugin/evm/limitorders/memory_database_test.go
+++ b/plugin/evm/limitorders/memory_database_test.go
@@ -112,7 +112,7 @@ func TestGetShortOrders(t *testing.T) {
 	shortOrder4.ReduceOnly = true
 	inMemoryDatabase.Add(orderId, &shortOrder4)
 
-	returnedShortOrders := inMemoryDatabase.GetShortOrders(market, nil)
+	returnedShortOrders := inMemoryDatabase.GetShortOrders(market, nil, nil)
 	assert.Equal(t, 3, len(returnedShortOrders))
 
 	for _, returnedOrder := range returnedShortOrders {
@@ -135,7 +135,7 @@ func TestGetShortOrders(t *testing.T) {
 	size := big.NewInt(0).Mul(big.NewInt(2), _1e18)
 	inMemoryDatabase.UpdatePosition(trader, market, size, big.NewInt(0).Mul(big.NewInt(100), _1e6), false)
 
-	returnedShortOrders = inMemoryDatabase.GetShortOrders(market, nil)
+	returnedShortOrders = inMemoryDatabase.GetShortOrders(market, nil, nil)
 	assert.Equal(t, 4, len(returnedShortOrders))
 
 	// at least one of the orders should be reduce only
@@ -188,7 +188,7 @@ func TestGetLongOrders(t *testing.T) {
 	longOrder3, orderId := createLimitOrder(LONG, userAddress, longOrderBaseAssetQuantity, price3, status, signature3, blockNumber3, salt3)
 	inMemoryDatabase.Add(orderId, &longOrder3)
 
-	returnedLongOrders := inMemoryDatabase.GetLongOrders(market, nil)
+	returnedLongOrders := inMemoryDatabase.GetLongOrders(market, nil, nil)
 	assert.Equal(t, 3, len(returnedLongOrders))
 
 	//Test returnedLongOrders are sorted by price highest to lowest first and then block number from lowest to highest

--- a/plugin/evm/limitorders/mocks.go
+++ b/plugin/evm/limitorders/mocks.go
@@ -16,7 +16,7 @@ func NewMockLimitOrderDatabase() *MockLimitOrderDatabase {
 	return &MockLimitOrderDatabase{}
 }
 
-func (db *MockLimitOrderDatabase) SetOrderStatus(orderId common.Hash, status Status, blockNumber uint64) error {
+func (db *MockLimitOrderDatabase) SetOrderStatus(orderId common.Hash, status Status, info string, blockNumber uint64) error {
 	return nil
 }
 

--- a/plugin/evm/limitorders/mocks.go
+++ b/plugin/evm/limitorders/mocks.go
@@ -41,12 +41,12 @@ func (db *MockLimitOrderDatabase) UpdateFilledBaseAssetQuantity(quantity *big.In
 func (db *MockLimitOrderDatabase) Delete(id common.Hash) {
 }
 
-func (db *MockLimitOrderDatabase) GetLongOrders(market Market, cutOff *big.Int) []LimitOrder {
+func (db *MockLimitOrderDatabase) GetLongOrders(market Market, lowerbound *big.Int, blockNumber *big.Int) []LimitOrder {
 	args := db.Called()
 	return args.Get(0).([]LimitOrder)
 }
 
-func (db *MockLimitOrderDatabase) GetShortOrders(market Market, cutOff *big.Int) []LimitOrder {
+func (db *MockLimitOrderDatabase) GetShortOrders(market Market, upperbound *big.Int, blockNumber *big.Int) []LimitOrder {
 	args := db.Called()
 	return args.Get(0).([]LimitOrder)
 }

--- a/plugin/evm/limitorders/service.go
+++ b/plugin/evm/limitorders/service.go
@@ -281,8 +281,13 @@ func getUpdateInDepth(newMarketDepth *MarketDepth, oldMarketDepth *MarketDepth) 
 }
 
 func getDepthForMarket(db LimitOrderDatabase, market Market) *MarketDepth {
-	longOrders := db.GetLongOrders(market, nil)
-	shortOrders := db.GetShortOrders(market, nil)
+	// currentBlock number only needs to be passed in for the retry logic for failed orders.
+	// There are some orders in the book that could have been marked failed,
+	// but because of our retry logic they might be retried every 100 blocks
+	// So, one could argue that is this not a super accurate representation of the order book
+	// BUT for the argument sake, we could also say that these retry orders can be treated as "fresh" orders
+	longOrders := db.GetLongOrders(market, nil /* lowerbound */, nil /* currentBlock */)
+	shortOrders := db.GetShortOrders(market, nil /* upperbound */, nil /* currentBlock */)
 	return &MarketDepth{
 		Market: market,
 		Longs:  aggregateOrdersByPrice(longOrders),


### PR DESCRIPTION
## Why this should be merged
- 🏃🏽‍♂️ Retry failed orders every 100 blocks 
```
Ideally these orders should have been auto-cancelled (by the validator) at the same time that they were fulfilling the criteria to fail
However, there are several reasons why this might not have happened
1. A particular cancellation strategy is not implemented yet for e.g. reduce only orders with order.BaseAssetQuantity > position.size are not being auto-cancelled as of Jun 20, 23. This is a @todo
2. There might be a scenarios that the order was not deemed cancellable at the time of checking and was hence used for matching; but then eventually failed execution
    a. a tx before the order in the same block, changed their PnL which caused them to have insufficient margin to execute the order
    b. specially true in multi-collateral, where the price of 1 collateral dipped but recovered again after the order was taken for matching (but failed execution)
3. There might be a bug in the cancellation logic in either of EVM or smart contract code
4. We might have made margin requirements for order fulfillment more liberal at a later stage
Hence, in view of the above and to serve as a catch-all we retry failed orders after every 100 blocks
Note at if an order is failing multiple times and it is also not being caught in the auto-cancel logic, then something/somewhere definitely needs fixing
```
- 🐛 Filter short orders by `price <= max(longOrders[0].price, liquidationUpperBound)`
- 📝 Add `Info` string in with order lifecycle struct to store descriptive errors.

