### PR TITLE
Run matching pipeline as soon as orders are received

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -324,7 +324,7 @@ func (self *DummyEngine) verifyBlockFee(
 	// by [baseFee].
 	if blockGas.Cmp(requiredBlockGasCost) < 0 {
 		return fmt.Errorf(
-			"insufficient gas (%d) to cover the block cost (%d) at base fee (%d) (total block fee: %d)",
+			"BLOCK_GAS_TOO_LOW: insufficient gas (%d) to cover the block cost (%d) at base fee (%d) (total block fee: %d)",
 			blockGas, requiredBlockGasCost, baseFee, totalBlockFee,
 		)
 	}

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -202,6 +202,17 @@ func updateLongWindow(window []byte, start uint64, gasConsumed uint64) {
 	binary.BigEndian.PutUint64(window[start:], totalGasConsumed)
 }
 
+func CalcBlockGasCost(
+	targetBlockRate uint64,
+	minBlockGasCost *big.Int,
+	maxBlockGasCost *big.Int,
+	blockGasCostStep *big.Int,
+	parentBlockGasCost *big.Int,
+	parentTime, currentTime uint64,
+) *big.Int {
+	return calcBlockGasCost(targetBlockRate, minBlockGasCost, maxBlockGasCost, blockGasCostStep, parentBlockGasCost, parentTime, currentTime)
+}
+
 // calcBlockGasCost calculates the required block gas cost. If [parentTime]
 // > [currentTime], the timeElapsed will be treated as 0.
 func calcBlockGasCost(

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -979,6 +979,17 @@ func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
 	return txs
 }
 
+func (pool *TxPool) GetOrderBookTxsCount() uint64 {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	count := 0
+	for _, txList := range pool.OrderBookTxMap {
+		count += txList.Len()
+	}
+	return uint64(count)
+}
+
 func (pool *TxPool) PurgeOrderBookTxs() {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -969,6 +969,9 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 }
 
 func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
 	txs := map[common.Address]types.Transactions{}
 	for from, txList := range pool.OrderBookTxMap {
 		txs[from] = txList.Flatten()
@@ -977,6 +980,10 @@ func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
 }
 
 func (pool *TxPool) PurgeOrderBookTxs() {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	log.Info("#### Purging orderbook txs")
 	for from, _ := range pool.OrderBookTxMap {
 		delete(pool.OrderBookTxMap, from)
 	}

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -32,7 +32,7 @@ const (
 	minBlockBuildingRetryDelay = 500 * time.Millisecond
 
 	// ticker frequency for calling signalTxsReady
-	buildTickerDuration = 1 * time.Second
+	buildTickerDuration = 5 * time.Second
 )
 
 type blockBuilder struct {
@@ -132,6 +132,9 @@ func (b *blockBuilder) markBuilding() {
 
 	select {
 	case b.notifyBuildBlockChan <- commonEng.PendingTxs:
+		// signal is sent here, so the ticker should be reset
+		b.buildTicker.Reset(buildTickerDuration)
+
 		b.buildSent = true
 	default:
 		log.Error("Failed to push PendingTxs notification to the consensus engine.")

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -29,7 +29,7 @@ const (
 
 	// Minimum amount of time to wait after building a block before attempting to build a block
 	// a second time without changing the contents of the mempool.
-	minBlockBuildingRetryDelay = 500 * time.Millisecond
+	minBlockBuildingRetryDelay = 50 * time.Millisecond
 
 	// ticker frequency for calling signalTxsReady
 	buildTickerDuration = 5 * time.Second
@@ -134,7 +134,6 @@ func (b *blockBuilder) markBuilding() {
 	case b.notifyBuildBlockChan <- commonEng.PendingTxs:
 		// signal is sent here, so the ticker should be reset
 		b.buildTicker.Reset(buildTickerDuration)
-
 		b.buildSent = true
 	default:
 		log.Error("Failed to push PendingTxs notification to the consensus engine.")
@@ -174,8 +173,6 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 			select {
 			case ethTxsEvent := <-txSubmitChan:
 				log.Trace("New tx detected, trying to generate a block")
-				// signalTxsReady is being called here, so the ticker should be reset
-				b.buildTicker.Reset(buildTickerDuration)
 				b.signalTxsReady()
 
 				if b.gossiper != nil && len(ethTxsEvent.Txs) > 0 {

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -132,6 +132,7 @@ func (b *blockBuilder) markBuilding() {
 
 	select {
 	case b.notifyBuildBlockChan <- commonEng.PendingTxs:
+		log.Info("#### markBuilding; signal sent", "b.buildSent", b.buildSent)
 		// signal is sent here, so the ticker should be reset
 		b.buildTicker.Reset(buildTickerDuration)
 		b.buildSent = true

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -164,6 +164,7 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 					lop.mu.Lock()
 					defer lop.mu.Unlock()
 					lop.contractEventProcessor.ProcessEvents(logs)
+					go lop.contractEventProcessor.ProcessTraderEvents(logs, "head")
 				}, orderbook.HandleHubbleFeedLogsPanicMessage, orderbook.HandleHubbleFeedLogsPanicsCounter)
 			case <-lop.shutdownChan:
 				return
@@ -185,6 +186,7 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 					lop.mu.Lock()
 					defer lop.mu.Unlock()
 					lop.contractEventProcessor.ProcessAcceptedEvents(logs, false)
+					go lop.contractEventProcessor.ProcessTraderEvents(logs, "accepted")
 				}, orderbook.HandleChainAcceptedLogsPanicMessage, orderbook.HandleChainAcceptedLogsPanicsCounter)
 			case <-lop.shutdownChan:
 				return

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -54,7 +54,7 @@ type limitOrderProcesser struct {
 	blockBuilder           *blockBuilder
 }
 
-func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string, blockBuilder *blockBuilder) LimitOrderProcesser {
+func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string) LimitOrderProcesser {
 	log.Info("**** NewLimitOrderProcesser")
 	configService := orderbook.NewConfigService(blockChain)
 	memoryDb := orderbook.NewInMemoryDatabase(configService)

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -32,7 +32,6 @@ const (
 
 type LimitOrderProcesser interface {
 	ListenAndProcessTransactions(blockBuilder *blockBuilder)
-	RunBuildBlockPipeline()
 	GetOrderBookAPI() *orderbook.OrderBookAPI
 	GetTradingAPI() *orderbook.TradingAPI
 }
@@ -48,20 +47,20 @@ type limitOrderProcesser struct {
 	memoryDb               orderbook.LimitOrderDatabase
 	limitOrderTxProcessor  orderbook.LimitOrderTxProcessor
 	contractEventProcessor *orderbook.ContractEventsProcessor
-	buildBlockPipeline     *orderbook.BuildBlockPipeline
+	matchingPipeline       *orderbook.MatchingPipeline
 	filterAPI              *filters.FilterAPI
 	hubbleDB               database.Database
 	configService          orderbook.IConfigService
 	blockBuilder           *blockBuilder
 }
 
-func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string) LimitOrderProcesser {
+func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string, blockBuilder *blockBuilder) LimitOrderProcesser {
 	log.Info("**** NewLimitOrderProcesser")
 	configService := orderbook.NewConfigService(blockChain)
 	memoryDb := orderbook.NewInMemoryDatabase(configService)
 	lotp := orderbook.NewLimitOrderTxProcessor(txPool, memoryDb, backend, validatorPrivateKey)
 	contractEventProcessor := orderbook.NewContractEventsProcessor(memoryDb)
-	buildBlockPipeline := orderbook.NewBuildBlockPipeline(memoryDb, lotp, configService)
+	matchingPipeline := orderbook.NewMatchingPipeline(memoryDb, lotp, configService)
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{})
 	filterAPI := filters.NewFilterAPI(filterSystem, true)
 
@@ -80,7 +79,7 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *core.TxPool, shutdownChan
 		blockChain:             blockChain,
 		limitOrderTxProcessor:  lotp,
 		contractEventProcessor: contractEventProcessor,
-		buildBlockPipeline:     buildBlockPipeline,
+		matchingPipeline:       matchingPipeline,
 		filterAPI:              filterAPI,
 		configService:          configService,
 	}
@@ -135,13 +134,17 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions(blockBuilder *block
 	lop.mu.Unlock()
 
 	lop.blockBuilder = blockBuilder
+	lop.runMatchingTimer()
 	lop.listenAndStoreLimitOrderTransactions()
 }
 
-func (lop *limitOrderProcesser) RunBuildBlockPipeline() {
+func (lop *limitOrderProcesser) RunMatchingPipeline() {
 	executeFuncAndRecoverPanic(func() {
-		lop.buildBlockPipeline.Run(new(big.Int).Add(lop.blockChain.CurrentBlock().Number(), big.NewInt(1)))
-	}, orderbook.RunBuildBlockPipelinePanicMessage, orderbook.RunBuildBlockPipelinePanicsCounter)
+		matchesFound := lop.matchingPipeline.Run(new(big.Int).Add(lop.blockChain.CurrentBlock().Number(), big.NewInt(1)))
+		if matchesFound {
+			lop.blockBuilder.signalTxsReady()
+		}
+	}, orderbook.RunMatchingPipelinePanicMessage, orderbook.RunMatchingPipelinePanicsCounter)
 }
 
 func (lop *limitOrderProcesser) GetOrderBookAPI() *orderbook.OrderBookAPI {
@@ -169,14 +172,7 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 					go lop.contractEventProcessor.PushtoTraderFeed(logs, orderbook.ConfirmationLevelHead)
 				}, orderbook.HandleHubbleFeedLogsPanicMessage, orderbook.HandleHubbleFeedLogsPanicsCounter)
 
-				executeFuncAndRecoverPanic(func() {
-					lop.buildBlockPipeline.Run(big.NewInt(int64(logs[0].BlockNumber + 1)))
-				}, orderbook.RunBuildBlockPipelinePanicMessage, orderbook.RunBuildBlockPipelinePanicsCounter)
-
-				if len(lop.txPool.GetOrderBookTxs()) > 0 {
-					log.Info("#### found unapplied txs after running build block pipeline", "txs", len(lop.txPool.GetOrderBookTxs()))
-					lop.blockBuilder.signalTxsReady()
-				}
+				lop.RunMatchingPipeline()
 
 			case <-lop.shutdownChan:
 				return
@@ -224,6 +220,25 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 			}
 		}
 	}()
+}
+
+// executes the matching pipeline periodically
+func (lop *limitOrderProcesser) runMatchingTimer() {
+	lop.shutdownWg.Add(1)
+	go executeFuncAndRecoverPanic(func() {
+		defer lop.shutdownWg.Done()
+
+		for {
+			select {
+			case <-lop.matchingPipeline.MatchingTicker.C:
+				lop.RunMatchingPipeline()
+
+			case <-lop.shutdownChan:
+				lop.matchingPipeline.MatchingTicker.Stop()
+				return
+			}
+		}
+	}, orderbook.RunMatchingPipelinePanicMessage, orderbook.RunMatchingPipelinePanicsCounter)
 }
 
 func (lop *limitOrderProcesser) handleChainAcceptedEvent(event core.ChainEvent) {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -113,13 +113,13 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
 		toBlock := utils.BigIntMin(lastAcceptedBlockNumber, big.NewInt(0).Add(fromBlock, JUMP))
 		for toBlock.Cmp(fromBlock) > 0 {
 			logs := lop.getLogs(fromBlock, toBlock)
-			log.Root().SetHandler(logHandler)
-			log.Info("ListenAndProcessTransactions - fetched log chunk", "fromBlock", fromBlock.String(), "toBlock", toBlock.String(), "number of logs", len(logs))
 			// set the log handler to discard logs so that the ProcessEvents doesn't spam the logs
 			log.Root().SetHandler(log.DiscardHandler())
 			lop.contractEventProcessor.ProcessEvents(logs)
 			lop.contractEventProcessor.ProcessAcceptedEvents(logs, true)
 			lop.memoryDb.Accept(toBlock.Uint64(), 0) // will delete stale orders from the memorydb
+			log.Root().SetHandler(logHandler)
+			log.Info("ListenAndProcessTransactions - processed log chunk", "fromBlock", fromBlock.String(), "toBlock", toBlock.String(), "number of logs", len(logs))
 
 			fromBlock = fromBlock.Add(toBlock, big.NewInt(1))
 			toBlock = utils.BigIntMin(lastAcceptedBlockNumber, big.NewInt(0).Add(fromBlock, JUMP))
@@ -128,7 +128,7 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
 		log.Root().SetHandler(logHandler)
 
 		// needs to be run everytime as long as the db.UpdatePosition uses configService.GetCumulativePremiumFraction
-		lop.FixBuggySnapshot()
+		lop.UpdateLastPremiumFractionFromStorage()
 	}
 
 	lop.mu.Unlock()
@@ -164,7 +164,7 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 					lop.mu.Lock()
 					defer lop.mu.Unlock()
 					lop.contractEventProcessor.ProcessEvents(logs)
-					go lop.contractEventProcessor.ProcessTraderEvents(logs, "head")
+					go lop.contractEventProcessor.PushtoTraderFeed(logs, orderbook.ConfirmationLevelHead)
 				}, orderbook.HandleHubbleFeedLogsPanicMessage, orderbook.HandleHubbleFeedLogsPanicsCounter)
 			case <-lop.shutdownChan:
 				return
@@ -186,7 +186,7 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 					lop.mu.Lock()
 					defer lop.mu.Unlock()
 					lop.contractEventProcessor.ProcessAcceptedEvents(logs, false)
-					go lop.contractEventProcessor.ProcessTraderEvents(logs, "accepted")
+					go lop.contractEventProcessor.PushtoTraderFeed(logs, orderbook.ConfirmationLevelAccepted)
 				}, orderbook.HandleChainAcceptedLogsPanicMessage, orderbook.HandleChainAcceptedLogsPanicsCounter)
 			case <-lop.shutdownChan:
 				return
@@ -332,7 +332,7 @@ func (lop *limitOrderProcesser) getLogs(fromBlock, toBlock *big.Int) []*types.Lo
 	return logs
 }
 
-func (lop *limitOrderProcesser) FixBuggySnapshot() {
+func (lop *limitOrderProcesser) UpdateLastPremiumFractionFromStorage() {
 	// This is to fix the bug that was causing the LastPremiumFraction to be set to 0 in the snapshot whenever a trader's position was updated
 	traderMap := lop.memoryDb.GetOrderBookData().TraderMap
 	count := 0
@@ -345,7 +345,7 @@ func (lop *limitOrderProcesser) FixBuggySnapshot() {
 			count++
 		}
 	}
-	log.Info("@@@@ updateLastPremiumFraction - update complete", "count", count, "time taken", time.Since(start))
+	log.Info("@@@@ UpdateLastPremiumFractionFromStorage - update complete", "count", count, "time taken", time.Since(start))
 }
 
 func executeFuncAndRecoverPanic(fn func(), panicMessage string, panicCounter metrics.Counter) {

--- a/plugin/evm/log.go
+++ b/plugin/evm/log.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	errorKey   = "LOG15_ERROR"
-	timeFormat = "2006-01-02T15:04:05.000-0700"
+	timeFormat = "2006-01-02T15:04:05.000000-0700"
 )
 
 type SubnetEVMLogger struct {

--- a/plugin/evm/log.go
+++ b/plugin/evm/log.go
@@ -102,7 +102,8 @@ func SubnetEVMJSONFormat(alias string) log.Format {
 func HubbleTypeHandler(h log.Handler) log.Handler {
 	return log.FuncHandler(func(r *log.Record) error {
 		var logType string
-		if strings.Contains(r.Call.Frame().File, "orderbook") || strings.Contains(r.Call.Frame().File, "limit_order") { // works for evm/limit_order.go and evm/orderbook/*.go
+		// works for evm/limit_order.go, evm/orderbook/*.go, precompile/contracts/*
+		if containsAnySubstr(r.Call.Frame().File, []string{"orderbook", "limit_order", "contracts"}) {
 			logType = "hubble"
 		} else {
 			logType = "system"
@@ -150,4 +151,14 @@ func formatJSONValue(value interface{}) (result interface{}) {
 	default:
 		return v
 	}
+}
+
+// containsAnySubstr checks if the string contains any of the specified substrings
+func containsAnySubstr(s string, substrings []string) bool {
+	for _, substr := range substrings {
+		if strings.Contains(s, substr) {
+			return true
+		}
+	}
+	return false
 }

--- a/plugin/evm/orderbook/abis/OrderBook.go
+++ b/plugin/evm/orderbook/abis/OrderBook.go
@@ -111,6 +111,49 @@ var OrderBookAbi = []byte(`{"abi": [
     "inputs": [
       {
         "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fillAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "openInterestNotional",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "OrderMatched",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "bytes32",
         "name": "orderHash",
         "type": "bytes32"
@@ -604,6 +647,24 @@ var OrderBookAbi = []byte(`{"abi": [
     "name": "placeOrders",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "authority",
+        "type": "address"
+      }
+    ],
+    "name": "setTradingAuthority",
+    "outputs": [],
+    "stateMutability": "payable",
     "type": "function"
   },
   {

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/metrics"
 	"github.com/ava-labs/subnet-evm/plugin/evm/orderbook/abis"
+	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -383,6 +384,111 @@ func (cep *ContractEventsProcessor) handleClearingHouseEvent(event *types.Log) {
 		size := args["size"].(*big.Int)
 		log.Info("PositionLiquidated", "market", market, "trader", trader, "args", args)
 		cep.database.UpdatePosition(trader, market, size, openNotional, true)
+	}
+}
+
+type TraderEvent struct {
+	Trader      common.Address
+	OrderId     common.Hash
+	OrderType   string
+	Removed     bool
+	EventName   string
+	Args        map[string]interface{}
+	BlockNumber *big.Int
+	BlockStatus string
+	Timestamp   interface{}
+}
+
+func (cep *ContractEventsProcessor) ProcessTraderEvents(events []*types.Log, blockStatus string) {
+	for _, event := range events {
+		removed := event.Removed
+		args := map[string]interface{}{}
+		eventName := ""
+		var orderId common.Hash
+		var orderType string
+		var trader common.Address
+		if len(event.Topics) > 1 {
+			trader = getAddressFromTopicHash(event.Topics[1])
+		}
+		if len(event.Topics) > 2 {
+			orderId = event.Topics[2]
+		}
+		switch event.Address {
+		case OrderBookContractAddress:
+			orderType = "limit"
+			switch event.Topics[0] {
+			case cep.orderBookABI.Events["OrderPlaced"].ID:
+				err := cep.orderBookABI.UnpackIntoMap(args, "OrderPlaced", event.Data)
+				if err != nil {
+					log.Error("error in orderBookABI.UnpackIntoMap", "method", "OrderPlaced", "err", err)
+					continue
+				}
+				eventName = "OrderPlaced"
+				order := LimitOrder{}
+				order.DecodeFromRawOrder(args["order"])
+				args["order"] = map[string]interface{}{
+					"ammIndex":          order.AmmIndex,
+					"trader":            order.Trader,
+					"baseAssetQuantity": utils.BigIntToFloat(order.BaseAssetQuantity, 18),
+					"price":             utils.BigIntToFloat(order.Price, 6),
+					"reduceOnly":        order.ReduceOnly,
+					"salt":              order.Salt,
+				}
+
+			case cep.orderBookABI.Events["OrderMatched"].ID:
+				err := cep.orderBookABI.UnpackIntoMap(args, "OrderMatched", event.Data)
+				if err != nil {
+					log.Error("error in orderBookABI.UnpackIntoMap", "method", "OrderMatched", "err", err)
+					continue
+				}
+				eventName = "OrderMatched"
+				fillAmount := args["fillAmount"].(*big.Int)
+				openInterestNotional := args["openInterestNotional"].(*big.Int)
+				price := args["price"].(*big.Int)
+				args["fillAmount"] = utils.BigIntToFloat(fillAmount, 18)
+				args["openInterestNotional"] = utils.BigIntToFloat(openInterestNotional, 18)
+				args["price"] = utils.BigIntToFloat(price, 6)
+
+			case cep.orderBookABI.Events["OrderCancelled"].ID:
+				err := cep.orderBookABI.UnpackIntoMap(args, "OrderCancelled", event.Data)
+				if err != nil {
+					log.Error("error in orderBookABI.UnpackIntoMap", "method", "OrderCancelled", "err", err)
+					continue
+				}
+				eventName = "OrderCancelled"
+
+			default:
+				continue
+			}
+
+		case IOCOrderBookContractAddress:
+			orderType = "ioc"
+			switch event.Topics[0] {
+			case cep.iocOrderBookABI.Events["OrderPlaced"].ID:
+				err := cep.iocOrderBookABI.UnpackIntoMap(args, "OrderPlaced", event.Data)
+				if err != nil {
+					log.Error("error in iocOrderBookABI.UnpackIntoMap", "method", "OrderPlaced", "err", err)
+					continue
+				}
+				eventName = "OrderPlaced"
+			}
+		default:
+			continue
+		}
+		timestamp, _ := args["timestamp"]
+		traderEvent := TraderEvent{
+			Trader:      trader,
+			Removed:     removed,
+			EventName:   eventName,
+			Args:        args,
+			BlockNumber: big.NewInt(int64(event.BlockNumber)),
+			BlockStatus: blockStatus,
+			OrderId:     orderId,
+			OrderType:   orderType,
+			Timestamp:   timestamp,
+		}
+
+		traderFeed.Send(traderEvent)
 	}
 }
 

--- a/plugin/evm/orderbook/errors.go
+++ b/plugin/evm/orderbook/errors.go
@@ -4,5 +4,5 @@ const (
 	HandleChainAcceptedEventPanicMessage = "panic while processing chainAcceptedEvent"
 	HandleChainAcceptedLogsPanicMessage  = "panic while processing chainAcceptedLogs"
 	HandleHubbleFeedLogsPanicMessage     = "panic while processing hubbleFeedLogs"
-	RunBuildBlockPipelinePanicMessage    = "panic while running buildBlockPipeline"
+	RunMatchingPipelinePanicMessage      = "panic while running matching pipeline"
 )

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -3,6 +3,7 @@ package orderbook
 import (
 	"math"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/ava-labs/subnet-evm/utils"
@@ -10,31 +11,49 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type BuildBlockPipeline struct {
-	db            LimitOrderDatabase
-	lotp          LimitOrderTxProcessor
-	configService IConfigService
+const (
+	// ticker frequency for calling signalTxsReady
+	matchingTickerDuration = 5 * time.Second
+)
+
+type MatchingPipeline struct {
+	mu             sync.Mutex
+	db             LimitOrderDatabase
+	lotp           LimitOrderTxProcessor
+	configService  IConfigService
+	MatchingTicker *time.Ticker
 }
 
-func NewBuildBlockPipeline(db LimitOrderDatabase, lotp LimitOrderTxProcessor, configService IConfigService) *BuildBlockPipeline {
-	return &BuildBlockPipeline{
-		db:            db,
-		lotp:          lotp,
-		configService: configService,
+func NewMatchingPipeline(
+	db LimitOrderDatabase,
+	lotp LimitOrderTxProcessor,
+	configService IConfigService) *MatchingPipeline {
+
+	return &MatchingPipeline{
+		db:             db,
+		lotp:           lotp,
+		configService:  configService,
+		MatchingTicker: time.NewTicker(matchingTickerDuration),
 	}
 }
 
-func (pipeline *BuildBlockPipeline) Run(blockNumber *big.Int) {
+func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
+	pipeline.mu.Lock()
+	defer pipeline.mu.Unlock()
+
+	// reset ticker
+	pipeline.MatchingTicker.Reset(matchingTickerDuration)
 	markets := pipeline.GetActiveMarkets()
 
 	if len(markets) == 0 {
-		return
+		return false
 	}
 
-	pipeline.lotp.PurgeLocalTx()
+	// start fresh and purge all local transactions
+	pipeline.lotp.PurgeOrderBookTxs()
 
 	if isFundingPaymentTime(pipeline.db.GetNextFundingTime()) {
-		log.Info("BuildBlockPipeline:isFundingPaymentTime")
+		log.Info("MatchingPipeline:isFundingPaymentTime")
 		err := executeFundingPayment(pipeline.lotp)
 		if err != nil {
 			log.Error("Funding payment job failed", "err", err)
@@ -56,6 +75,14 @@ func (pipeline *BuildBlockPipeline) Run(blockNumber *big.Int) {
 		// @todo should we prioritize matching in any particular market?
 		pipeline.runMatchingEngine(pipeline.lotp, orderMap[market].longOrders, orderMap[market].shortOrders)
 	}
+
+	orderBookTxsCount := pipeline.lotp.GetOrderBookTxsCount()
+	if orderBookTxsCount > 0 {
+		log.Info("#### found unapplied txs after running build block pipeline", "txs", orderBookTxsCount)
+		return true
+	}
+
+	return false
 }
 
 type Orders struct {
@@ -63,9 +90,7 @@ type Orders struct {
 	shortOrders []Order
 }
 
-type Market int64
-
-func (pipeline *BuildBlockPipeline) GetActiveMarkets() []Market {
+func (pipeline *MatchingPipeline) GetActiveMarkets() []Market {
 	count := pipeline.configService.GetActiveMarketsCount()
 	markets := make([]Market, count)
 	for i := int64(0); i < count; i++ {
@@ -74,7 +99,7 @@ func (pipeline *BuildBlockPipeline) GetActiveMarkets() []Market {
 	return markets
 }
 
-func (pipeline *BuildBlockPipeline) GetUnderlyingPrices() map[Market]*big.Int {
+func (pipeline *MatchingPipeline) GetUnderlyingPrices() map[Market]*big.Int {
 	prices := pipeline.configService.GetUnderlyingPrices()
 	log.Info("GetUnderlyingPrices", "prices", prices)
 	underlyingPrices := make(map[Market]*big.Int)
@@ -84,7 +109,7 @@ func (pipeline *BuildBlockPipeline) GetUnderlyingPrices() map[Market]*big.Int {
 	return underlyingPrices
 }
 
-func (pipeline *BuildBlockPipeline) cancelLimitOrders(cancellableOrders map[common.Address][]Order) map[common.Hash]struct{} {
+func (pipeline *MatchingPipeline) cancelLimitOrders(cancellableOrders map[common.Address][]Order) map[common.Hash]struct{} {
 	cancellableOrderIds := map[common.Hash]struct{}{}
 	// @todo: if there are too many cancellable orders, they might not fit in a single block. Need to adjust for that.
 	for _, orders := range cancellableOrders {
@@ -109,7 +134,7 @@ func (pipeline *BuildBlockPipeline) cancelLimitOrders(cancellableOrders map[comm
 	return cancellableOrderIds
 }
 
-func (pipeline *BuildBlockPipeline) fetchOrders(market Market, underlyingPrice *big.Int, cancellableOrderIds map[common.Hash]struct{}, blockNumber *big.Int) *Orders {
+func (pipeline *MatchingPipeline) fetchOrders(market Market, underlyingPrice *big.Int, cancellableOrderIds map[common.Hash]struct{}, blockNumber *big.Int) *Orders {
 	_, lowerBoundForLongs := pipeline.configService.GetAcceptableBounds(market)
 	// any long orders below the permissible lowerbound are irrelevant, because they won't be matched no matter what.
 	// this assumes that all above cancelOrder transactions got executed successfully (or atleast they are not meant to be executed anyway if they passed the cancellation criteria)
@@ -129,7 +154,7 @@ func (pipeline *BuildBlockPipeline) fetchOrders(market Market, underlyingPrice *
 	return &Orders{longOrders, shortOrders}
 }
 
-func (pipeline *BuildBlockPipeline) runLiquidations(liquidablePositions []LiquidablePosition, orderMap map[Market]*Orders, underlyingPrices map[Market]*big.Int) {
+func (pipeline *MatchingPipeline) runLiquidations(liquidablePositions []LiquidablePosition, orderMap map[Market]*Orders, underlyingPrices map[Market]*big.Int) {
 	if len(liquidablePositions) == 0 {
 		return
 	}
@@ -195,7 +220,7 @@ func (pipeline *BuildBlockPipeline) runLiquidations(liquidablePositions []Liquid
 	}
 }
 
-func (pipeline *BuildBlockPipeline) runMatchingEngine(lotp LimitOrderTxProcessor, longOrders []Order, shortOrders []Order) {
+func (pipeline *MatchingPipeline) runMatchingEngine(lotp LimitOrderTxProcessor, longOrders []Order, shortOrders []Order) {
 	if len(longOrders) == 0 || len(shortOrders) == 0 {
 		return
 	}

--- a/plugin/evm/orderbook/matching_pipeline_test.go
+++ b/plugin/evm/orderbook/matching_pipeline_test.go
@@ -525,11 +525,11 @@ func getLiquidablePos(address common.Address, posType PositionType, size int64) 
 	}
 }
 
-func setupDependencies(t *testing.T) (*MockLimitOrderDatabase, *MockLimitOrderTxProcessor, *BuildBlockPipeline, map[Market]*big.Int, *MockConfigService) {
+func setupDependencies(t *testing.T) (*MockLimitOrderDatabase, *MockLimitOrderTxProcessor, *MatchingPipeline, map[Market]*big.Int, *MockConfigService) {
 	db := NewMockLimitOrderDatabase()
 	lotp := NewMockLimitOrderTxProcessor()
 	cs := NewMockConfigService()
-	pipeline := NewBuildBlockPipeline(db, lotp, cs)
+	pipeline := NewMatchingPipeline(db, lotp, cs)
 	underlyingPrices := make(map[Market]*big.Int)
 	underlyingPrices[market] = big.NewInt(20.0)
 	return db, lotp, pipeline, underlyingPrices, cs

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -49,6 +49,8 @@ const (
 	RETRY_AFTER_BLOCKS = 10
 )
 
+type Market int64
+
 type Collateral int
 
 const (

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -153,7 +153,7 @@ func (order Order) getExpireAt() *big.Int {
 }
 
 func (order Order) String() string {
-	return fmt.Sprintf("LimitOrder: Id: %s, Market: %v, PositionType: %v, UserAddress: %v, BaseAssetQuantity: %s, FilledBaseAssetQuantity: %s, Salt: %v, Price: %s, ReduceOnly: %v, BlockNumber: %s", order.Id, order.Market, order.PositionType, order.UserAddress, prettifyScaledBigInt(order.BaseAssetQuantity, 18), prettifyScaledBigInt(order.FilledBaseAssetQuantity, 18), order.Salt, prettifyScaledBigInt(order.Price, 6), order.ReduceOnly, order.BlockNumber)
+	return fmt.Sprintf("Order: Id: %s, OrderType: %s, Market: %v, PositionType: %v, UserAddress: %v, BaseAssetQuantity: %s, FilledBaseAssetQuantity: %s, Salt: %v, Price: %s, ReduceOnly: %v, BlockNumber: %s", order.Id, order.OrderType, order.Market, order.PositionType, order.UserAddress, prettifyScaledBigInt(order.BaseAssetQuantity, 18), prettifyScaledBigInt(order.FilledBaseAssetQuantity, 18), order.Salt, prettifyScaledBigInt(order.Price, 6), order.ReduceOnly, order.BlockNumber)
 }
 
 func (order Order) ToOrderMin() OrderMin {

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -225,7 +225,7 @@ type LimitOrderDatabase interface {
 	SetOrderStatus(orderId common.Hash, status Status, info string, blockNumber uint64) error
 	RevertLastStatus(orderId common.Hash) error
 	GetNaughtyTraders(oraclePrices map[Market]*big.Int, markets []Market) ([]LiquidablePosition, map[common.Address][]Order)
-	GetOpenOrdersForTrader(trader common.Address) []Order
+	GetOpenOrdersForTrader(trader common.Address, orderType OrderType) []Order
 	UpdateLastPremiumFraction(market Market, trader common.Address, lastPremiumFraction *big.Int, cumlastPremiumFraction *big.Int)
 	GetOrderById(orderId common.Hash) *Order
 	GetTraderInfo(trader common.Address) *Trader
@@ -571,11 +571,11 @@ func (db *InMemoryDatabase) GetAllTraders() map[common.Address]Trader {
 	return traderMap
 }
 
-func (db *InMemoryDatabase) GetOpenOrdersForTrader(trader common.Address) []Order {
+func (db *InMemoryDatabase) GetOpenOrdersForTrader(trader common.Address, orderType OrderType) []Order {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
-	return db.getTraderOrders(trader)
+	return db.getTraderOrders(trader, orderType)
 }
 
 func (db *InMemoryDatabase) GetOrderById(orderId common.Hash) *Order {
@@ -682,7 +682,7 @@ func (db *InMemoryDatabase) GetNaughtyTraders(oraclePrices map[Market]*big.Int, 
 
 // assumes db.mu.RLock has been held by the caller
 func (db *InMemoryDatabase) determineOrdersToCancel(addr common.Address, trader *Trader, availableMargin *big.Int, oraclePrices map[Market]*big.Int, ordersToCancel map[common.Address][]Order) bool {
-	traderOrders := db.getTraderOrders(addr)
+	traderOrders := db.getTraderOrders(addr, LimitOrderType)
 	sort.Slice(traderOrders, func(i, j int) bool {
 		// higher diff comes first
 		iDiff := big.NewInt(0).Abs(big.NewInt(0).Sub(traderOrders[i].Price, oraclePrices[traderOrders[i].Market]))
@@ -712,11 +712,11 @@ func (db *InMemoryDatabase) determineOrdersToCancel(addr common.Address, trader 
 	return false
 }
 
-func (db *InMemoryDatabase) getTraderOrders(trader common.Address) []Order {
+func (db *InMemoryDatabase) getTraderOrders(trader common.Address, orderType OrderType) []Order {
 	traderOrders := []Order{}
 	_trader := trader.String()
 	for _, order := range db.OrderMap {
-		if strings.EqualFold(order.UserAddress, _trader) {
+		if strings.EqualFold(order.UserAddress, _trader) && order.OrderType == orderType {
 			traderOrders = append(traderOrders, deepCopyOrder(order))
 		}
 	}

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -23,4 +23,6 @@ var (
 	HandleChainAcceptedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
 	HandleChainAcceptedEventPanicsCounter    = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)
 	HandleMatchingPipelineTimerPanicsCounter = metrics.NewRegisteredCounter("handle_matching_pipeline_timer_panics", nil)
+
+	BuildBlockFailedWithLowBlockGasCounter = metrics.NewRegisteredCounter("build_block_failed_low_block_gas", nil)
 )

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -18,8 +18,9 @@ var (
 	orderBookTransactionsFailureTotalCounter = metrics.NewRegisteredCounter("orderbooktxs/total/failure", nil)
 
 	// panics are recovered but monitored
-	RunBuildBlockPipelinePanicsCounter    = metrics.NewRegisteredCounter("build_block_pipeline_panics", nil)
-	HandleHubbleFeedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_hubble_feed_logs_panics", nil)
-	HandleChainAcceptedLogsPanicsCounter  = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
-	HandleChainAcceptedEventPanicsCounter = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)
+	RunMatchingPipelinePanicsCounter         = metrics.NewRegisteredCounter("matching_pipeline_panics", nil)
+	HandleHubbleFeedLogsPanicsCounter        = metrics.NewRegisteredCounter("handle_hubble_feed_logs_panics", nil)
+	HandleChainAcceptedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
+	HandleChainAcceptedEventPanicsCounter    = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)
+	HandleMatchingPipelineTimerPanicsCounter = metrics.NewRegisteredCounter("handle_matching_pipeline_timer_panics", nil)
 )

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -120,7 +120,7 @@ func (db *MockLimitOrderDatabase) LoadFromSnapshot(snapshot Snapshot) error {
 	return nil
 }
 
-func (db *MockLimitOrderDatabase) GetOpenOrdersForTrader(trader common.Address) []Order {
+func (db *MockLimitOrderDatabase) GetOpenOrdersForTrader(trader common.Address, orderType OrderType) []Order {
 	return nil
 }
 

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -148,12 +148,13 @@ func (lotp *MockLimitOrderTxProcessor) ExecuteMatchedOrdersTx(incomingOrder Orde
 	return args.Error(0)
 }
 
-func (lotp *MockLimitOrderTxProcessor) PurgeLocalTx() {
+func (lotp *MockLimitOrderTxProcessor) PurgeOrderBookTxs() {
 	lotp.Called()
 }
 
-func (lotp *MockLimitOrderTxProcessor) CheckIfOrderBookContractCall(tx *types.Transaction) bool {
-	return true
+func (lotp *MockLimitOrderTxProcessor) GetOrderBookTxsCount() uint64 {
+	args := lotp.Called()
+	return uint64(args.Int(0))
 }
 
 func (lotp *MockLimitOrderTxProcessor) ExecuteFundingPaymentTx() error {

--- a/plugin/evm/orderbook/order_types.go
+++ b/plugin/evm/orderbook/order_types.go
@@ -6,12 +6,14 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/subnet-evm/accounts/abi"
+	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 
 type ContractOrder interface {
 	EncodeToABI() ([]byte, error)
 	DecodeFromRawOrder(rawOrder interface{})
+	Map() map[string]interface{}
 }
 
 // LimitOrder type is copy of LimitOrder struct defined in Orderbook contract
@@ -58,6 +60,17 @@ func (order *LimitOrder) DecodeFromRawOrder(rawOrder interface{}) {
 	json.Unmarshal(marshalledOrder, &order)
 }
 
+func (order *LimitOrder) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"ammIndex":          order.AmmIndex,
+		"trader":            order.Trader,
+		"baseAssetQuantity": utils.BigIntToFloat(order.BaseAssetQuantity, 18),
+		"price":             utils.BigIntToFloat(order.Price, 6),
+		"reduceOnly":        order.ReduceOnly,
+		"salt":              order.Salt,
+	}
+}
+
 func DecodeLimitOrder(encodedOrder []byte) (*LimitOrder, error) {
 	limitOrderType, err := getOrderType("limit")
 	if err != nil {
@@ -99,6 +112,19 @@ func (order *IOCOrder) EncodeToABI() ([]byte, error) {
 func (order *IOCOrder) DecodeFromRawOrder(rawOrder interface{}) {
 	marshalledOrder, _ := json.Marshal(rawOrder)
 	json.Unmarshal(marshalledOrder, &order)
+}
+
+func (order *IOCOrder) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"ammIndex":          order.AmmIndex,
+		"trader":            order.Trader,
+		"baseAssetQuantity": utils.BigIntToFloat(order.BaseAssetQuantity, 18),
+		"price":             utils.BigIntToFloat(order.Price, 6),
+		"reduceOnly":        order.ReduceOnly,
+		"salt":              order.Salt,
+		"orderType":         order.OrderType,
+		"expireAt":          order.ExpireAt,
+	}
 }
 
 func DecodeIOCOrder(encodedOrder []byte) (*IOCOrder, error) {

--- a/plugin/evm/orderbook/service.go
+++ b/plugin/evm/orderbook/service.go
@@ -57,6 +57,7 @@ type OrderForOpenOrders struct {
 	Salt       string
 	OrderId    string
 	ReduceOnly bool
+	OrderType  OrderType
 }
 
 type GetDebugDataResponse struct {
@@ -166,7 +167,7 @@ func (api *OrderBookAPI) GetOpenOrders(ctx context.Context, trader string, marke
 	}
 	traderOrders := []OrderForOpenOrders{}
 	traderHash := common.HexToAddress(trader)
-	orders := api.db.GetOpenOrdersForTrader(traderHash)
+	orders := api.db.GetOpenOrdersForTrader(traderHash, LimitOrderType)
 	for _, order := range orders {
 		if strings.EqualFold(order.UserAddress, trader) && (market == nil || order.Market == Market(*market)) {
 			traderOrders = append(traderOrders, OrderForOpenOrders{
@@ -177,6 +178,7 @@ func (api *OrderBookAPI) GetOpenOrders(ctx context.Context, trader string, marke
 				Salt:       order.Salt.String(),
 				OrderId:    order.Id.String(),
 				ReduceOnly: order.ReduceOnly,
+				OrderType:  order.OrderType,
 			})
 		}
 	}

--- a/plugin/evm/orderbook/trader_feed.go
+++ b/plugin/evm/orderbook/trader_feed.go
@@ -1,0 +1,1 @@
+package orderbook

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -7,13 +7,17 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/ava-labs/subnet-evm/eth"
 	"github.com/ava-labs/subnet-evm/rpc"
 	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/event"
 )
+
+var traderFeed event.Feed
 
 type TradingAPI struct {
 	db            LimitOrderDatabase
@@ -250,4 +254,28 @@ func transformMarketDepth(depth *MarketDepth) TradingOrderBookDepthResponse {
 	}
 
 	return response
+}
+
+func (api *TradingAPI) StreamTraderUpdates(ctx context.Context, trader string, blockStatus string) (*rpc.Subscription, error) {
+	notifier, _ := rpc.NotifierFromContext(ctx)
+	rpcSub := notifier.CreateSubscription()
+
+	traderFeedCh := make(chan TraderEvent)
+	acceptedLogsSubscription := traderFeed.Subscribe(traderFeedCh)
+	go func() {
+		defer acceptedLogsSubscription.Unsubscribe()
+
+		for {
+			select {
+			case event := <-traderFeedCh:
+				if strings.EqualFold(event.Trader.String(), trader) && event.BlockStatus == blockStatus {
+					notifier.Notify(rpcSub.ID, event)
+				}
+			case <-notifier.Closed():
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
 }

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -259,6 +259,7 @@ func transformMarketDepth(depth *MarketDepth) TradingOrderBookDepthResponse {
 func (api *TradingAPI) StreamTraderUpdates(ctx context.Context, trader string, blockStatus string) (*rpc.Subscription, error) {
 	notifier, _ := rpc.NotifierFromContext(ctx)
 	rpcSub := notifier.CreateSubscription()
+	confirmationLevel := BlockConfirmationLevel(blockStatus)
 
 	traderFeedCh := make(chan TraderEvent)
 	acceptedLogsSubscription := traderFeed.Subscribe(traderFeedCh)
@@ -268,7 +269,7 @@ func (api *TradingAPI) StreamTraderUpdates(ctx context.Context, trader string, b
 		for {
 			select {
 			case event := <-traderFeedCh:
-				if strings.EqualFold(event.Trader.String(), trader) && event.BlockStatus == blockStatus {
+				if strings.EqualFold(event.Trader.String(), trader) && event.BlockStatus == confirmationLevel {
 					notifier.Notify(rpcSub.ID, event)
 				}
 			case <-notifier.Closed():

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -299,6 +299,7 @@ func (lotp *limitOrderTxProcessor) UpdateMetrics(block *types.Block) {
 			if contractAddress != nil && lotp.orderBookContractAddress == *contractAddress {
 				note := "success"
 				if receipt.Status == 0 {
+					log.Error("orderbook tx failed", "method", method.Name, "tx", tx.Hash().String(), "receipt", receipt)
 					note = "failure"
 				}
 				counterName := fmt.Sprintf("orderbooktxs/%s/%s", method.Name, note)

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -194,17 +194,6 @@ func (lotp *limitOrderTxProcessor) updateValidatorTxFeeConfig() {
 }
 
 func (lotp *limitOrderTxProcessor) PurgeLocalTx() {
-	pending := lotp.txPool.Pending(true)
-	for _, txs := range pending {
-		for _, tx := range txs {
-			method, err := getOrderBookContractCallMethod(tx, lotp.orderBookABI, lotp.orderBookContractAddress)
-			if err == nil {
-				if method.Name == "executeMatchedOrders" || method.Name == "settleFunding" || method.Name == "liquidateAndExecuteOrder" {
-					lotp.txPool.RemoveTx(tx.Hash())
-				}
-			}
-		}
-	}
 	lotp.txPool.PurgeOrderBookTxs()
 }
 

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -6,10 +6,8 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ava-labs/subnet-evm/accounts/abi"
-	"github.com/ava-labs/subnet-evm/consensus/dummy"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/eth"
@@ -186,7 +184,7 @@ func (lotp *limitOrderTxProcessor) getTransactionFee() *big.Int {
 	baseFeeEstimate, err := lotp.backend.SuggestPrice(context.Background())
 	if err != nil {
 		log.Error("getBaseFeeEstimate - SuggestPrice failed", "err", err)
-		return big.NewInt(65_000000000) // hardcoded to 70 gwei
+		return big.NewInt(65_000000000) // hardcoded to 65 gwei
 	}
 	// add 10%
 	baseFeeEstimate.Add(baseFeeEstimate, big.NewInt(0).Div(baseFeeEstimate, big.NewInt(10)))
@@ -198,15 +196,9 @@ func (lotp *limitOrderTxProcessor) getTransactionFee() *big.Int {
 		baseFeeEstimate.Add(baseFeeEstimate, big.NewInt(0).Div(baseFeeEstimate, big.NewInt(10)))
 		return baseFeeEstimate
 	}
-
-	blockGasCost := dummy.CalcBlockGasCost(
-		feeConfig.TargetBlockRate,
-		feeConfig.MinBlockGasCost,
-		feeConfig.MaxBlockGasCost,
-		feeConfig.BlockGasCostStep,
-		latest.BlockGasCost,
-		latest.Time, uint64(time.Now().Unix()),
-	)
+	// assuming pessimistically that the block is being produced within a second of the latest block
+	// we calculate the block gas cost as the latest block gas cost + the block gas cost step
+	blockGasCost := big.NewInt(0).Add(latest.BlockGasCost, feeConfig.BlockGasCostStep)
 
 	// assuming a minimum gas usage of 200k for a tx, we calculate the tip such that the entire block has an effective tip above the threshold
 	// example calculation for blockGasCost = 10,000, baseFeeEstimate = 60 gwei, tx gas usage = 200,000

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/ava-labs/subnet-evm/accounts/abi"
+	"github.com/ava-labs/subnet-evm/consensus/dummy"
 	"github.com/ava-labs/subnet-evm/core"
 	"github.com/ava-labs/subnet-evm/core/types"
 	"github.com/ava-labs/subnet-evm/eth"
@@ -27,8 +29,8 @@ var IOCOrderBookContractAddress = common.HexToAddress("0x635c5F96989a4226953FE63
 // var IOCOrderBookContractAddress = common.HexToAddress("0x0300000000000000000000000000000000000006")
 
 type LimitOrderTxProcessor interface {
-	PurgeLocalTx()
-	CheckIfOrderBookContractCall(tx *types.Transaction) bool
+	GetOrderBookTxsCount() uint64
+	PurgeOrderBookTxs()
 	ExecuteMatchedOrdersTx(incomingOrder Order, matchedOrder Order, fillAmount *big.Int) error
 	ExecuteFundingPaymentTx() error
 	ExecuteLiquidation(trader common.Address, matchedOrder Order, fillAmount *big.Int) error
@@ -94,7 +96,6 @@ func NewLimitOrderTxProcessor(txPool *core.TxPool, memoryDb LimitOrderDatabase, 
 		validatorPrivateKey:          validatorPrivateKey,
 		validatorTxFeeConfig:         ValidatorTxFeeConfig{baseFeeEstimate: big.NewInt(0), blockNumber: 0},
 	}
-	lotp.updateValidatorTxFeeConfig()
 	return lotp
 }
 
@@ -143,7 +144,6 @@ func (lotp *limitOrderTxProcessor) ExecuteLimitOrderCancel(orders []LimitOrder) 
 
 func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contractABI abi.ABI, method string, args ...interface{}) (common.Hash, error) {
 	var txHash common.Hash
-	lotp.updateValidatorTxFeeConfig()
 	nonce := lotp.txPool.GetOrderBookTxNonce(common.HexToAddress(lotp.validatorAddress.Hex())) // admin address
 
 	data, err := contractABI.Pack(method, args...)
@@ -156,7 +156,8 @@ func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contr
 		log.Error("HexToECDSA failed", "err", err)
 		return txHash, err
 	}
-	tx := types.NewTransaction(nonce, contract, big.NewInt(0), 1500000, lotp.validatorTxFeeConfig.baseFeeEstimate, data)
+	txFee := lotp.getTransactionFee()
+	tx := types.NewTransaction(nonce, contract, big.NewInt(0), 1500000, txFee, data)
 	signer := types.NewLondonSigner(lotp.backend.ChainConfig().ChainID)
 	signedTx, err := types.SignTx(tx, signer, key)
 	if err != nil {
@@ -169,36 +170,62 @@ func (lotp *limitOrderTxProcessor) executeLocalTx(contract common.Address, contr
 		log.Error("lop.txPool.AddOrderBookTx failed", "err", err, "tx", signedTx.Hash().String(), "nonce", nonce)
 		return txHash, err
 	}
-	// log.Info("executeLocalTx - AddOrderBookTx success", "tx", signedTx.Hash().String(), "nonce", nonce)
 
 	return txHash, nil
 }
 
-func (lotp *limitOrderTxProcessor) getBaseFeeEstimate() *big.Int {
-	baseFeeEstimate, err := lotp.backend.EstimateBaseFee(context.TODO())
+func (lotp *limitOrderTxProcessor) getTransactionFee() *big.Int {
+	latest := lotp.backend.CurrentHeader()
+	latestBlockNumber := latest.Number.Uint64()
+
+	// if the fee is already calculated for this block, then return it
+	if lotp.validatorTxFeeConfig.blockNumber == latestBlockNumber {
+		return lotp.validatorTxFeeConfig.baseFeeEstimate
+	}
+
+	baseFeeEstimate, err := lotp.backend.SuggestPrice(context.Background())
 	if err != nil {
-		baseFeeEstimate = big.NewInt(0).Abs(lotp.backend.CurrentBlock().BaseFee())
-		log.Error("Error in calculating updated bassFee, using last header's baseFee", "baseFeeEstimate", baseFeeEstimate)
+		log.Error("getBaseFeeEstimate - SuggestPrice failed", "err", err)
+		return big.NewInt(65_000000000) // hardcoded to 70 gwei
 	}
-	return baseFeeEstimate
+	// add 10%
+	baseFeeEstimate.Add(baseFeeEstimate, big.NewInt(0).Div(baseFeeEstimate, big.NewInt(10)))
+
+	feeConfig, _, err := lotp.backend.GetFeeConfigAt(latest)
+	if err != nil {
+		log.Error("getBaseFeeEstimate - GetFeeConfigAt failed", "err", err)
+		// if feeConfig can't be obtained, then add another 10% to the baseFeeEstimate
+		baseFeeEstimate.Add(baseFeeEstimate, big.NewInt(0).Div(baseFeeEstimate, big.NewInt(10)))
+		return baseFeeEstimate
+	}
+
+	blockGasCost := dummy.CalcBlockGasCost(
+		feeConfig.TargetBlockRate,
+		feeConfig.MinBlockGasCost,
+		feeConfig.MaxBlockGasCost,
+		feeConfig.BlockGasCostStep,
+		latest.BlockGasCost,
+		latest.Time, uint64(time.Now().Unix()),
+	)
+
+	// assuming a minimum gas usage of 200k for a tx, we calculate the tip such that the entire block has an effective tip above the threshold
+	// example calculation for blockGasCost = 10,000, baseFeeEstimate = 60 gwei, tx gas usage = 200,000
+	// tip = (10000 * 60 * 1e9) / 200000 = 3 gwei
+	tip := big.NewInt(0).Div(big.NewInt(0).Mul(blockGasCost, baseFeeEstimate), big.NewInt(200000))
+
+	totalFee := baseFeeEstimate.Add(baseFeeEstimate, tip)
+
+	lotp.validatorTxFeeConfig.baseFeeEstimate = totalFee
+	lotp.validatorTxFeeConfig.blockNumber = latestBlockNumber
+	return totalFee
 }
 
-func (lotp *limitOrderTxProcessor) updateValidatorTxFeeConfig() {
-	currentBlockNumber := lotp.backend.CurrentBlock().NumberU64()
-	if lotp.validatorTxFeeConfig.blockNumber < currentBlockNumber {
-		baseFeeEstimate := lotp.getBaseFeeEstimate()
-		// log.Info("inside lotp updating txFeeConfig", "blockNumber", currentBlockNumber, "baseFeeEstimate", baseFeeEstimate)
-		lotp.validatorTxFeeConfig.baseFeeEstimate = baseFeeEstimate
-		lotp.validatorTxFeeConfig.blockNumber = currentBlockNumber
-	}
-}
-
-func (lotp *limitOrderTxProcessor) PurgeLocalTx() {
+func (lotp *limitOrderTxProcessor) PurgeOrderBookTxs() {
 	lotp.txPool.PurgeOrderBookTxs()
 }
 
-func (lotp *limitOrderTxProcessor) CheckIfOrderBookContractCall(tx *types.Transaction) bool {
-	return checkIfOrderBookContractCall(tx, lotp.orderBookABI, lotp.orderBookContractAddress)
+func (lotp *limitOrderTxProcessor) GetOrderBookTxsCount() uint64 {
+	return lotp.txPool.GetOrderBookTxsCount()
 }
 
 func getPositionTypeBasedOnBaseAssetQuantity(baseAssetQuantity *big.Int) PositionType {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ava-labs/subnet-evm/params"
 	"github.com/ava-labs/subnet-evm/peer"
 	"github.com/ava-labs/subnet-evm/plugin/evm/message"
+	"github.com/ava-labs/subnet-evm/plugin/evm/orderbook"
 	"github.com/ava-labs/subnet-evm/rpc"
 	statesyncclient "github.com/ava-labs/subnet-evm/sync/client"
 	"github.com/ava-labs/subnet-evm/sync/client/stats"
@@ -688,7 +689,14 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 	block, err := vm.miner.GenerateBlock(predicateCtx)
 	vm.builder.handleGenerateBlock()
 	if err != nil {
-		log.Error("buildBlock - GenerateBlock failed", "err", err)
+
+		if vm.txPool.GetOrderBookTxsCount() > 0 && strings.Contains(err.Error(), "BLOCK_GAS_TOO_LOW") {
+			// orderbook txs from the validator were part of the block that failed to be generated because of low block gas
+			orderbook.BuildBlockFailedWithLowBlockGasCounter.Inc(1)
+			log.Error("buildBlock - GenerateBlock failed with low gas cost", "err", err, "orderbookTxsCount", vm.txPool.GetOrderBookTxsCount())
+		} else {
+			log.Error("buildBlock - GenerateBlock failed", "err", err)
+		}
 		return nil, err
 	}
 
@@ -1015,7 +1023,6 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 		vm.blockChain,
 		vm.hubbleDB,
 		validatorPrivateKey,
-		vm.builder,
 	)
 }
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -674,9 +674,9 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 	}(time.Now())
 
 	if proposerVMBlockCtx != nil {
-		log.Debug("Building block with context", "pChainBlockHeight", proposerVMBlockCtx.PChainHeight)
+		log.Info("Building block with context", "pChainBlockHeight", proposerVMBlockCtx.PChainHeight)
 	} else {
-		log.Debug("Building block without context")
+		log.Info("Building block without context")
 	}
 	predicateCtx := &precompileconfig.ProposerPredicateContext{
 		PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -23,6 +23,8 @@ avalanche subnet create hubblenet --force --custom --genesis genesis.json --vm c
 
 # configure and add chain.json
 avalanche subnet configure hubblenet --chain-config chain.json --config .avalanche-cli.json
+avalanche subnet configure hubblenet --subnet-config subnet.json --config .avalanche-cli.json
+# avalanche subnet configure hubblenet --subnet-config 2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx.json --config .avalanche-cli.json
 # avalanche subnet configure hubblenet --per-node-chain-config node_config.json --config .avalanche-cli.json
 
 # use the same avalanchego version as the one used in subnet-evm

--- a/scripts/upgrade_local.sh
+++ b/scripts/upgrade_local.sh
@@ -2,9 +2,9 @@
 set -e
 source ./scripts/utils.sh
 
-avalanche network stop --snapshot-name snap1
-
 ./scripts/build.sh custom_evm.bin
+
+avalanche network stop --snapshot-name snap1
 
 avalanche subnet upgrade vm hubblenet --binary custom_evm.bin --local
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -23,20 +23,28 @@ function showLogs() {
 
     source local_status.sh
     if [ -z "$1" ]; then
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/1/g')/$CHAIN_ID.log | sed 's/^/[node1]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/2/g')/$CHAIN_ID.log | sed 's/^/[node2]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/3/g')/$CHAIN_ID.log | sed 's/^/[node3]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/4/g')/$CHAIN_ID.log | sed 's/^/[node4]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/5/g')/$CHAIN_ID.log | sed 's/^/[node5]: /'
+        # Define colors and nodes
 
-        multitail -D -ci magenta --label "[node1]" $(echo $LOGS_PATH | sed -e 's/<i>/1/g')/$CHAIN_ID.log \
-            -ci green --label "[node2]" -I $(echo $LOGS_PATH | sed -e 's/<i>/2/g')/$CHAIN_ID.log \
-            -ci white --label "[node3]" -I $(echo $LOGS_PATH | sed -e 's/<i>/3/g')/$CHAIN_ID.log \
-            -ci yellow --label "[node4]" -I $(echo $LOGS_PATH | sed -e 's/<i>/4/g')/$CHAIN_ID.log \
-            -ci cyan --label "[node5]" -I $(echo $LOGS_PATH | sed -e 's/<i>/5/g')/$CHAIN_ID.log
+        colors=("magenta" "green" "white" "yellow" "cyan")
+        nodes=("1" "2" "3" "4" "5")
+
+        # Use for loop to iterate through nodes
+        for index in ${!nodes[*]}
+        do
+            node=${nodes[$index]}
+            color=${colors[$index]}
+            logs_path=$(echo $LOGS_PATH | sed -e "s/<i>/$node/g")
+            # Add multitail command for each node
+            cmd_part+=" -ci $color --label \"[node$node]\" -I ${logs_path}/$CHAIN_ID.log"
+        done
+
+        # Execute multitail with the generated command parts
+        eval "multitail -D $cmd_part"
+
     else
         if [ -z "$2" ]; then
-            tail -f "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
+            # from the beginning
+            tail -f -n +1 "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
         else
             grep --color=auto -i "$2" "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
         fi

--- a/subnet.json
+++ b/subnet.json
@@ -1,0 +1,3 @@
+{
+    "proposerMinBlockDelay": "0s"
+}

--- a/utils/bigint.go
+++ b/utils/bigint.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math"
 	"math/big"
 )
 
@@ -50,4 +51,9 @@ func BigIntToDecimal(x *big.Int, scale int, decimals int) string {
 	str := fmt.Sprintf("%.*f", decimals, f)
 
 	return str
+}
+
+func BigIntToFloat(number *big.Int, scale int8) float64 {
+	float, _ := new(big.Float).Quo(new(big.Float).SetInt(number), big.NewFloat(math.Pow10(int(scale)))).Float64()
+	return float
 }


### PR DESCRIPTION
## Code changes
- Estimate block gas cost along with base fee while adding validator transactions
- Rename BuildBlockPipeline to MatchingPipeline
- Matching engine automatically calls buildBlock if there are valid transactions
- Run matching pipeline when head block is received
- Run matching pipeline every 5 seconds; and remove 5 second timer from buildBlock
- Add subnet.json file. There's a pending issue with applying subnet config right now

## How this was tested
- On local
