### PR TITLE
Run matching pipeline as soon as orders are received

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -321,7 +321,7 @@ func (self *DummyEngine) verifyBlockFee(
 	// by [baseFee].
 	if blockGas.Cmp(requiredBlockGasCost) < 0 {
 		return fmt.Errorf(
-			"insufficient gas (%d) to cover the block cost (%d) at base fee (%d) (total block fee: %d)",
+			"BLOCK_GAS_TOO_LOW: insufficient gas (%d) to cover the block cost (%d) at base fee (%d) (total block fee: %d)",
 			blockGas, requiredBlockGasCost, baseFee, totalBlockFee,
 		)
 	}

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -202,6 +202,17 @@ func updateLongWindow(window []byte, start uint64, gasConsumed uint64) {
 	binary.BigEndian.PutUint64(window[start:], totalGasConsumed)
 }
 
+func CalcBlockGasCost(
+	targetBlockRate uint64,
+	minBlockGasCost *big.Int,
+	maxBlockGasCost *big.Int,
+	blockGasCostStep *big.Int,
+	parentBlockGasCost *big.Int,
+	parentTime, currentTime uint64,
+) *big.Int {
+	return calcBlockGasCost(targetBlockRate, minBlockGasCost, maxBlockGasCost, blockGasCostStep, parentBlockGasCost, parentTime, currentTime)
+}
+
 // calcBlockGasCost calculates the required block gas cost. If [parentTime]
 // > [currentTime], the timeElapsed will be treated as 0.
 func calcBlockGasCost(

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -202,17 +202,6 @@ func updateLongWindow(window []byte, start uint64, gasConsumed uint64) {
 	binary.BigEndian.PutUint64(window[start:], totalGasConsumed)
 }
 
-func CalcBlockGasCost(
-	targetBlockRate uint64,
-	minBlockGasCost *big.Int,
-	maxBlockGasCost *big.Int,
-	blockGasCostStep *big.Int,
-	parentBlockGasCost *big.Int,
-	parentTime, currentTime uint64,
-) *big.Int {
-	return calcBlockGasCost(targetBlockRate, minBlockGasCost, maxBlockGasCost, blockGasCostStep, parentBlockGasCost, parentTime, currentTime)
-}
-
 // calcBlockGasCost calculates the required block gas cost. If [parentTime]
 // > [currentTime], the timeElapsed will be treated as 0.
 func calcBlockGasCost(

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1040,6 +1040,9 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 }
 
 func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
 	txs := map[common.Address]types.Transactions{}
 	for from, txList := range pool.OrderBookTxMap {
 		txs[from] = txList.Flatten()
@@ -1048,6 +1051,10 @@ func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
 }
 
 func (pool *TxPool) PurgeOrderBookTxs() {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	log.Info("#### Purging orderbook txs")
 	for from, _ := range pool.OrderBookTxMap {
 		delete(pool.OrderBookTxMap, from)
 	}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1065,7 +1065,6 @@ func (pool *TxPool) PurgeOrderBookTxs() {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
-	log.Info("#### Purging orderbook txs")
 	for from, _ := range pool.OrderBookTxMap {
 		delete(pool.OrderBookTxMap, from)
 	}

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1050,6 +1050,17 @@ func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
 	return txs
 }
 
+func (pool *TxPool) GetOrderBookTxsCount() uint64 {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	count := 0
+	for _, txList := range pool.OrderBookTxMap {
+		count += txList.Len()
+	}
+	return uint64(count)
+}
+
 func (pool *TxPool) PurgeOrderBookTxs() {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -21,9 +21,6 @@ const (
 	// Minimum amount of time to wait after building a block before attempting to build a block
 	// a second time without changing the contents of the mempool.
 	minBlockBuildingRetryDelay = 50 * time.Millisecond
-
-	// ticker frequency for calling signalTxsReady
-	buildTickerDuration = 1 * time.Second
 )
 
 type blockBuilder struct {
@@ -52,10 +49,6 @@ type blockBuilder struct {
 	// If the mempool receives a new transaction, the block builder will send a new notification to
 	// the engine and cancel the timer.
 	buildBlockTimer *timer.Timer
-
-	// buildTicker notifies the consensus periodically so that funding payments and order matching can continue
-	// even when there are no pending transactions in the mempool
-	buildTicker *time.Ticker
 }
 
 func (vm *VM) NewBlockBuilder(notifyBuildBlockChan chan<- commonEng.Message) *blockBuilder {
@@ -67,7 +60,6 @@ func (vm *VM) NewBlockBuilder(notifyBuildBlockChan chan<- commonEng.Message) *bl
 		shutdownChan:         vm.shutdownChan,
 		shutdownWg:           &vm.shutdownWg,
 		notifyBuildBlockChan: notifyBuildBlockChan,
-		buildTicker:          time.NewTicker(buildTickerDuration),
 	}
 	b.handleBlockBuilding()
 	return b
@@ -123,9 +115,6 @@ func (b *blockBuilder) markBuilding() {
 
 	select {
 	case b.notifyBuildBlockChan <- commonEng.PendingTxs:
-		log.Info("#### markBuilding; signal sent", "b.buildSent", b.buildSent)
-		// signal is sent here, so the ticker should be reset
-		b.buildTicker.Reset(buildTickerDuration)
 		b.buildSent = true
 	default:
 		log.Error("Failed to push PendingTxs notification to the consensus engine.")
@@ -179,25 +168,6 @@ func (b *blockBuilder) awaitSubmittedTxs() {
 				}
 			case <-b.shutdownChan:
 				b.buildBlockTimer.Stop()
-				return
-			}
-		}
-	})
-}
-
-// notifies the consensus to attempt buildBlock periodically
-func (b *blockBuilder) awaitBuildTimer() {
-	b.shutdownWg.Add(1)
-	go b.ctx.Log.RecoverAndPanic(func() {
-		defer b.shutdownWg.Done()
-
-		for {
-			select {
-			case <-b.buildTicker.C:
-				b.signalTxsReady()
-
-			case <-b.shutdownChan:
-				b.buildTicker.Stop()
 				return
 			}
 		}

--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -123,6 +123,7 @@ func (b *blockBuilder) markBuilding() {
 
 	select {
 	case b.notifyBuildBlockChan <- commonEng.PendingTxs:
+		log.Info("#### markBuilding; signal sent", "b.buildSent", b.buildSent)
 		// signal is sent here, so the ticker should be reset
 		b.buildTicker.Reset(buildTickerDuration)
 		b.buildSent = true

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -32,7 +32,7 @@ const (
 )
 
 type LimitOrderProcesser interface {
-	ListenAndProcessTransactions()
+	ListenAndProcessTransactions(blockBuilder *blockBuilder)
 	RunBuildBlockPipeline()
 	GetOrderBookAPI() *orderbook.OrderBookAPI
 	GetTradingAPI() *orderbook.TradingAPI
@@ -53,6 +53,7 @@ type limitOrderProcesser struct {
 	filterAPI              *filters.FilterAPI
 	hubbleDB               database.Database
 	configService          orderbook.IConfigService
+	blockBuilder           *blockBuilder
 }
 
 func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string) LimitOrderProcesser {
@@ -86,7 +87,7 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownCh
 	}
 }
 
-func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
+func (lop *limitOrderProcesser) ListenAndProcessTransactions(blockBuilder *blockBuilder) {
 	lop.mu.Lock()
 
 	lastAccepted := lop.blockChain.LastAcceptedBlock()
@@ -134,6 +135,7 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions() {
 
 	lop.mu.Unlock()
 
+	lop.blockBuilder = blockBuilder
 	lop.listenAndStoreLimitOrderTransactions()
 }
 
@@ -167,6 +169,16 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 					lop.contractEventProcessor.ProcessEvents(logs)
 					go lop.contractEventProcessor.PushtoTraderFeed(logs, orderbook.ConfirmationLevelHead)
 				}, orderbook.HandleHubbleFeedLogsPanicMessage, orderbook.HandleHubbleFeedLogsPanicsCounter)
+
+				executeFuncAndRecoverPanic(func() {
+					lop.buildBlockPipeline.Run(big.NewInt(int64(logs[0].BlockNumber + 1)))
+				}, orderbook.RunBuildBlockPipelinePanicMessage, orderbook.RunBuildBlockPipelinePanicsCounter)
+
+				if len(lop.txPool.GetOrderBookTxs()) > 0 {
+					log.Info("#### found unapplied txs after running build block pipeline", "txs", len(lop.txPool.GetOrderBookTxs()))
+					lop.blockBuilder.signalTxsReady()
+				}
+
 			case <-lop.shutdownChan:
 				return
 			}
@@ -219,7 +231,7 @@ func (lop *limitOrderProcesser) handleChainAcceptedEvent(event core.ChainEvent) 
 	lop.mu.Lock()
 	defer lop.mu.Unlock()
 	block := event.Block
-	log.Info("#### received ChainAcceptedEvent", "number", block.NumberU64(), "hash", block.Hash().String())
+	log.Info("received ChainAcceptedEvent", "number", block.NumberU64(), "hash", block.Hash().String())
 	lop.memoryDb.Accept(block.NumberU64(), block.Time())
 
 	// update metrics asynchronously

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -55,7 +55,7 @@ type limitOrderProcesser struct {
 	blockBuilder           *blockBuilder
 }
 
-func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string, blockBuilder *blockBuilder) LimitOrderProcesser {
+func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string) LimitOrderProcesser {
 	log.Info("**** NewLimitOrderProcesser")
 	configService := orderbook.NewConfigService(blockChain)
 	memoryDb := orderbook.NewInMemoryDatabase(configService)

--- a/plugin/evm/orderbook/errors.go
+++ b/plugin/evm/orderbook/errors.go
@@ -4,5 +4,5 @@ const (
 	HandleChainAcceptedEventPanicMessage = "panic while processing chainAcceptedEvent"
 	HandleChainAcceptedLogsPanicMessage  = "panic while processing chainAcceptedLogs"
 	HandleHubbleFeedLogsPanicMessage     = "panic while processing hubbleFeedLogs"
-	RunBuildBlockPipelinePanicMessage    = "panic while running buildBlockPipeline"
+	RunMatchingPipelinePanicMessage      = "panic while running matching pipeline"
 )

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -3,6 +3,7 @@ package orderbook
 import (
 	"math"
 	"math/big"
+	"sync"
 	"time"
 
 	"github.com/ava-labs/subnet-evm/utils"
@@ -10,31 +11,49 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type BuildBlockPipeline struct {
-	db            LimitOrderDatabase
-	lotp          LimitOrderTxProcessor
-	configService IConfigService
+const (
+	// ticker frequency for calling signalTxsReady
+	matchingTickerDuration = 5 * time.Second
+)
+
+type MatchingPipeline struct {
+	mu             sync.Mutex
+	db             LimitOrderDatabase
+	lotp           LimitOrderTxProcessor
+	configService  IConfigService
+	MatchingTicker *time.Ticker
 }
 
-func NewBuildBlockPipeline(db LimitOrderDatabase, lotp LimitOrderTxProcessor, configService IConfigService) *BuildBlockPipeline {
-	return &BuildBlockPipeline{
-		db:            db,
-		lotp:          lotp,
-		configService: configService,
+func NewMatchingPipeline(
+	db LimitOrderDatabase,
+	lotp LimitOrderTxProcessor,
+	configService IConfigService) *MatchingPipeline {
+
+	return &MatchingPipeline{
+		db:             db,
+		lotp:           lotp,
+		configService:  configService,
+		MatchingTicker: time.NewTicker(matchingTickerDuration),
 	}
 }
 
-func (pipeline *BuildBlockPipeline) Run(blockNumber *big.Int) {
+func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
+	pipeline.mu.Lock()
+	defer pipeline.mu.Unlock()
+
+	// reset ticker
+	pipeline.MatchingTicker.Reset(matchingTickerDuration)
 	markets := pipeline.GetActiveMarkets()
 
 	if len(markets) == 0 {
-		return
+		return false
 	}
 
-	pipeline.lotp.PurgeLocalTx()
+	// start fresh and purge all local transactions
+	pipeline.lotp.PurgeOrderBookTxs()
 
 	if isFundingPaymentTime(pipeline.db.GetNextFundingTime()) {
-		log.Info("BuildBlockPipeline:isFundingPaymentTime")
+		log.Info("MatchingPipeline:isFundingPaymentTime")
 		err := executeFundingPayment(pipeline.lotp)
 		if err != nil {
 			log.Error("Funding payment job failed", "err", err)
@@ -56,6 +75,14 @@ func (pipeline *BuildBlockPipeline) Run(blockNumber *big.Int) {
 		// @todo should we prioritize matching in any particular market?
 		pipeline.runMatchingEngine(pipeline.lotp, orderMap[market].longOrders, orderMap[market].shortOrders)
 	}
+
+	orderBookTxsCount := pipeline.lotp.GetOrderBookTxsCount()
+	if orderBookTxsCount > 0 {
+		log.Info("#### found unapplied txs after running build block pipeline", "txs", orderBookTxsCount)
+		return true
+	}
+
+	return false
 }
 
 type Orders struct {
@@ -63,9 +90,7 @@ type Orders struct {
 	shortOrders []Order
 }
 
-type Market int64
-
-func (pipeline *BuildBlockPipeline) GetActiveMarkets() []Market {
+func (pipeline *MatchingPipeline) GetActiveMarkets() []Market {
 	count := pipeline.configService.GetActiveMarketsCount()
 	markets := make([]Market, count)
 	for i := int64(0); i < count; i++ {
@@ -74,7 +99,7 @@ func (pipeline *BuildBlockPipeline) GetActiveMarkets() []Market {
 	return markets
 }
 
-func (pipeline *BuildBlockPipeline) GetUnderlyingPrices() map[Market]*big.Int {
+func (pipeline *MatchingPipeline) GetUnderlyingPrices() map[Market]*big.Int {
 	prices := pipeline.configService.GetUnderlyingPrices()
 	log.Info("GetUnderlyingPrices", "prices", prices)
 	underlyingPrices := make(map[Market]*big.Int)
@@ -84,7 +109,7 @@ func (pipeline *BuildBlockPipeline) GetUnderlyingPrices() map[Market]*big.Int {
 	return underlyingPrices
 }
 
-func (pipeline *BuildBlockPipeline) cancelLimitOrders(cancellableOrders map[common.Address][]Order) map[common.Hash]struct{} {
+func (pipeline *MatchingPipeline) cancelLimitOrders(cancellableOrders map[common.Address][]Order) map[common.Hash]struct{} {
 	cancellableOrderIds := map[common.Hash]struct{}{}
 	// @todo: if there are too many cancellable orders, they might not fit in a single block. Need to adjust for that.
 	for _, orders := range cancellableOrders {
@@ -109,7 +134,7 @@ func (pipeline *BuildBlockPipeline) cancelLimitOrders(cancellableOrders map[comm
 	return cancellableOrderIds
 }
 
-func (pipeline *BuildBlockPipeline) fetchOrders(market Market, underlyingPrice *big.Int, cancellableOrderIds map[common.Hash]struct{}, blockNumber *big.Int) *Orders {
+func (pipeline *MatchingPipeline) fetchOrders(market Market, underlyingPrice *big.Int, cancellableOrderIds map[common.Hash]struct{}, blockNumber *big.Int) *Orders {
 	_, lowerBoundForLongs := pipeline.configService.GetAcceptableBounds(market)
 	// any long orders below the permissible lowerbound are irrelevant, because they won't be matched no matter what.
 	// this assumes that all above cancelOrder transactions got executed successfully (or atleast they are not meant to be executed anyway if they passed the cancellation criteria)
@@ -129,7 +154,7 @@ func (pipeline *BuildBlockPipeline) fetchOrders(market Market, underlyingPrice *
 	return &Orders{longOrders, shortOrders}
 }
 
-func (pipeline *BuildBlockPipeline) runLiquidations(liquidablePositions []LiquidablePosition, orderMap map[Market]*Orders, underlyingPrices map[Market]*big.Int) {
+func (pipeline *MatchingPipeline) runLiquidations(liquidablePositions []LiquidablePosition, orderMap map[Market]*Orders, underlyingPrices map[Market]*big.Int) {
 	if len(liquidablePositions) == 0 {
 		return
 	}
@@ -195,7 +220,7 @@ func (pipeline *BuildBlockPipeline) runLiquidations(liquidablePositions []Liquid
 	}
 }
 
-func (pipeline *BuildBlockPipeline) runMatchingEngine(lotp LimitOrderTxProcessor, longOrders []Order, shortOrders []Order) {
+func (pipeline *MatchingPipeline) runMatchingEngine(lotp LimitOrderTxProcessor, longOrders []Order, shortOrders []Order) {
 	if len(longOrders) == 0 || len(shortOrders) == 0 {
 		return
 	}

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -78,7 +78,6 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 
 	orderBookTxsCount := pipeline.lotp.GetOrderBookTxsCount()
 	if orderBookTxsCount > 0 {
-		log.Info("#### found unapplied txs after running build block pipeline", "txs", orderBookTxsCount)
 		return true
 	}
 

--- a/plugin/evm/orderbook/matching_pipeline_test.go
+++ b/plugin/evm/orderbook/matching_pipeline_test.go
@@ -525,11 +525,11 @@ func getLiquidablePos(address common.Address, posType PositionType, size int64) 
 	}
 }
 
-func setupDependencies(t *testing.T) (*MockLimitOrderDatabase, *MockLimitOrderTxProcessor, *BuildBlockPipeline, map[Market]*big.Int, *MockConfigService) {
+func setupDependencies(t *testing.T) (*MockLimitOrderDatabase, *MockLimitOrderTxProcessor, *MatchingPipeline, map[Market]*big.Int, *MockConfigService) {
 	db := NewMockLimitOrderDatabase()
 	lotp := NewMockLimitOrderTxProcessor()
 	cs := NewMockConfigService()
-	pipeline := NewBuildBlockPipeline(db, lotp, cs)
+	pipeline := NewMatchingPipeline(db, lotp, cs)
 	underlyingPrices := make(map[Market]*big.Int)
 	underlyingPrices[market] = big.NewInt(20.0)
 	return db, lotp, pipeline, underlyingPrices, cs

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -49,6 +49,8 @@ const (
 	RETRY_AFTER_BLOCKS = 10
 )
 
+type Market int64
+
 type Collateral int
 
 const (

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -23,4 +23,6 @@ var (
 	HandleChainAcceptedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
 	HandleChainAcceptedEventPanicsCounter    = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)
 	HandleMatchingPipelineTimerPanicsCounter = metrics.NewRegisteredCounter("handle_matching_pipeline_timer_panics", nil)
+
+	BuildBlockFailedWithLowBlockGasCounter = metrics.NewRegisteredCounter("build_block_failed_low_block_gas", nil)
 )

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -18,8 +18,9 @@ var (
 	orderBookTransactionsFailureTotalCounter = metrics.NewRegisteredCounter("orderbooktxs/total/failure", nil)
 
 	// panics are recovered but monitored
-	RunBuildBlockPipelinePanicsCounter    = metrics.NewRegisteredCounter("build_block_pipeline_panics", nil)
-	HandleHubbleFeedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_hubble_feed_logs_panics", nil)
-	HandleChainAcceptedLogsPanicsCounter  = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
-	HandleChainAcceptedEventPanicsCounter = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)
+	RunMatchingPipelinePanicsCounter         = metrics.NewRegisteredCounter("matching_pipeline_panics", nil)
+	HandleHubbleFeedLogsPanicsCounter        = metrics.NewRegisteredCounter("handle_hubble_feed_logs_panics", nil)
+	HandleChainAcceptedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
+	HandleChainAcceptedEventPanicsCounter    = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)
+	HandleMatchingPipelineTimerPanicsCounter = metrics.NewRegisteredCounter("handle_matching_pipeline_timer_panics", nil)
 )

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -152,12 +152,13 @@ func (lotp *MockLimitOrderTxProcessor) ExecuteMatchedOrdersTx(incomingOrder Orde
 	return args.Error(0)
 }
 
-func (lotp *MockLimitOrderTxProcessor) PurgeLocalTx() {
+func (lotp *MockLimitOrderTxProcessor) PurgeOrderBookTxs() {
 	lotp.Called()
 }
 
-func (lotp *MockLimitOrderTxProcessor) CheckIfOrderBookContractCall(tx *types.Transaction) bool {
-	return true
+func (lotp *MockLimitOrderTxProcessor) GetOrderBookTxsCount() uint64 {
+	args := lotp.Called()
+	return uint64(args.Int(0))
 }
 
 func (lotp *MockLimitOrderTxProcessor) ExecuteFundingPaymentTx() error {

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -194,17 +194,6 @@ func (lotp *limitOrderTxProcessor) updateValidatorTxFeeConfig() {
 }
 
 func (lotp *limitOrderTxProcessor) PurgeLocalTx() {
-	pending := lotp.txPool.Pending(true)
-	for _, txs := range pending {
-		for _, tx := range txs {
-			method, err := getOrderBookContractCallMethod(tx, lotp.orderBookABI, lotp.orderBookContractAddress)
-			if err == nil {
-				if method.Name == "executeMatchedOrders" || method.Name == "settleFunding" || method.Name == "liquidateAndExecuteOrder" {
-					lotp.txPool.RemoveTx(tx.Hash())
-				}
-			}
-		}
-	}
 	lotp.txPool.PurgeOrderBookTxs()
 }
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -626,7 +626,6 @@ func (vm *VM) initBlockBuilding() {
 	vm.gossiper = vm.createGossiper(gossipStats)
 	vm.builder = vm.NewBlockBuilder(vm.toEngine)
 	vm.builder.awaitSubmittedTxs()
-	vm.builder.awaitBuildTimer()
 	vm.Network.SetGossipHandler(NewGossipHandler(vm, gossipStats))
 
 	vm.limitOrderProcesser.ListenAndProcessTransactions(vm.builder)
@@ -691,21 +690,15 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 	}(time.Now())
 
 	if proposerVMBlockCtx != nil {
-		log.Info("#### Building block with context", "pChainBlockHeight", proposerVMBlockCtx.PChainHeight)
+		log.Info("Building block with context", "pChainBlockHeight", proposerVMBlockCtx.PChainHeight)
 	} else {
-		log.Info("#### Building block without context")
+		log.Info("Building block without context")
 	}
 	predicateCtx := &precompileconfig.ProposerPredicateContext{
 		PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
 			SnowCtx: vm.ctx,
 		},
 		ProposerVMBlockCtx: proposerVMBlockCtx,
-	}
-
-	// if there are no orderbook txs in the txpool, we need to run the build block pipeline
-	if len(vm.txPool.GetOrderBookTxs()) == 0 {
-		log.Info("#### running BuildBlockPipeline in buildBlock")
-		vm.limitOrderProcesser.RunBuildBlockPipeline()
 	}
 
 	block, err := vm.miner.GenerateBlock(predicateCtx)
@@ -1039,6 +1032,7 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 		vm.blockChain,
 		vm.hubbleDB,
 		validatorPrivateKey,
+		vm.builder,
 	)
 }
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -629,7 +629,7 @@ func (vm *VM) initBlockBuilding() {
 	vm.builder.awaitBuildTimer()
 	vm.Network.SetGossipHandler(NewGossipHandler(vm, gossipStats))
 
-	vm.limitOrderProcesser.ListenAndProcessTransactions()
+	vm.limitOrderProcesser.ListenAndProcessTransactions(vm.builder)
 }
 
 // setAppRequestHandlers sets the request handlers for the VM to serve state sync
@@ -687,12 +687,13 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 		}
 
 		buildBlockTimeHistogram.Update(time.Since(start).Microseconds())
+		log.Info("#### buildBlock complete", "duration", time.Since(start))
 	}(time.Now())
 
 	if proposerVMBlockCtx != nil {
-		log.Info("Building block with context", "pChainBlockHeight", proposerVMBlockCtx.PChainHeight)
+		log.Info("#### Building block with context", "pChainBlockHeight", proposerVMBlockCtx.PChainHeight)
 	} else {
-		log.Info("Building block without context")
+		log.Info("#### Building block without context")
 	}
 	predicateCtx := &precompileconfig.ProposerPredicateContext{
 		PrecompilePredicateContext: precompileconfig.PrecompilePredicateContext{
@@ -701,7 +702,12 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 		ProposerVMBlockCtx: proposerVMBlockCtx,
 	}
 
-	vm.limitOrderProcesser.RunBuildBlockPipeline()
+	// if there are no orderbook txs in the txpool, we need to run the build block pipeline
+	if len(vm.txPool.GetOrderBookTxs()) == 0 {
+		log.Info("#### running BuildBlockPipeline in buildBlock")
+		vm.limitOrderProcesser.RunBuildBlockPipeline()
+	}
+
 	block, err := vm.miner.GenerateBlock(predicateCtx)
 	vm.builder.handleGenerateBlock()
 	if err != nil {

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -23,6 +23,8 @@ avalanche subnet create hubblenet --force --custom --genesis genesis.json --vm c
 
 # configure and add chain.json
 avalanche subnet configure hubblenet --chain-config chain.json --config .avalanche-cli.json
+avalanche subnet configure hubblenet --subnet-config subnet.json --config .avalanche-cli.json
+# avalanche subnet configure hubblenet --subnet-config 2TGBXcnwx5PqiXWiqxAKUaNSqDguXNh1mxnp82jui68hxJSZAx.json --config .avalanche-cli.json
 # avalanche subnet configure hubblenet --per-node-chain-config node_config.json --config .avalanche-cli.json
 
 # use the same avalanchego version as the one used in subnet-evm

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -23,20 +23,28 @@ function showLogs() {
 
     source local_status.sh
     if [ -z "$1" ]; then
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/1/g')/$CHAIN_ID.log | sed 's/^/[node1]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/2/g')/$CHAIN_ID.log | sed 's/^/[node2]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/3/g')/$CHAIN_ID.log | sed 's/^/[node3]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/4/g')/$CHAIN_ID.log | sed 's/^/[node4]: /' &
-        # tail -f $(echo $LOGS_PATH | sed -e 's/<i>/5/g')/$CHAIN_ID.log | sed 's/^/[node5]: /'
+        # Define colors and nodes
 
-        multitail -D -ci magenta --label "[node1]" $(echo $LOGS_PATH | sed -e 's/<i>/1/g')/$CHAIN_ID.log \
-            -ci green --label "[node2]" -I $(echo $LOGS_PATH | sed -e 's/<i>/2/g')/$CHAIN_ID.log \
-            -ci white --label "[node3]" -I $(echo $LOGS_PATH | sed -e 's/<i>/3/g')/$CHAIN_ID.log \
-            -ci yellow --label "[node4]" -I $(echo $LOGS_PATH | sed -e 's/<i>/4/g')/$CHAIN_ID.log \
-            -ci cyan --label "[node5]" -I $(echo $LOGS_PATH | sed -e 's/<i>/5/g')/$CHAIN_ID.log
+        colors=("magenta" "green" "white" "yellow" "cyan")
+        nodes=("1" "2" "3" "4" "5")
+
+        # Use for loop to iterate through nodes
+        for index in ${!nodes[*]}
+        do
+            node=${nodes[$index]}
+            color=${colors[$index]}
+            logs_path=$(echo $LOGS_PATH | sed -e "s/<i>/$node/g")
+            # Add multitail command for each node
+            cmd_part+=" -ci $color --label \"[node$node]\" -I ${logs_path}/$CHAIN_ID.log"
+        done
+
+        # Execute multitail with the generated command parts
+        eval "multitail -D $cmd_part"
+
     else
         if [ -z "$2" ]; then
-            tail -f "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
+            # from the beginning
+            tail -f -n +1 "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
         else
             grep --color=auto -i "$2" "${LOGS_PATH/<i>/$1}/$CHAIN_ID.log"
         fi

--- a/subnet.json
+++ b/subnet.json
@@ -1,3 +1,3 @@
 {
-    "proposerMinBlockDelay": "0s"
+    "proposerMinBlockDelay": 0
 }

--- a/subnet.json
+++ b/subnet.json
@@ -1,0 +1,3 @@
+{
+    "proposerMinBlockDelay": "0s"
+}


### PR DESCRIPTION
## Code changes
- Estimate block gas cost along with base fee while adding validator transactions
- Rename BuildBlockPipeline to MatchingPipeline
- Matching engine automatically calls buildBlock if there are valid transactions
- Run matching pipeline when head block is received
- Run matching pipeline every 5 seconds; and remove 5 second timer from buildBlock
- Add subnet.json file. There's a pending issue with applying subnet config right now
- Add a metric for when build block fails because of low block gas and it contains orderbook transactions

## How this was tested
- On local
