### PR TITLE
updated Dockerfile to correct subnet id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@ COPY . .
 ARG SUBNET_EVM_COMMIT
 ARG CURRENT_BRANCH
 
-RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && export CURRENT_BRANCH=$CURRENT_BRANCH && ./scripts/build.sh /build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
+RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && export CURRENT_BRANCH=$CURRENT_BRANCH && ./scripts/build.sh /build/o1Fg94YukvVRijwyThAavybVfwVJH3dhyz94g6qYRGdQ5Arqp
 
 # ============= Cleanup Stage ================
 FROM avaplatform/avalanchego:$AVALANCHE_VERSION AS builtImage
 
 # Copy the evm binary into the correct location in the container
-COPY --from=builder /build/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy /avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
+COPY --from=builder /build/o1Fg94YukvVRijwyThAavybVfwVJH3dhyz94g6qYRGdQ5Arqp /avalanchego/build/plugins/o1Fg94YukvVRijwyThAavybVfwVJH3dhyz94g6qYRGdQ5Arqp


### PR DESCRIPTION
## Why this should be merged
With this change, the subnet build is placed in the right location for avalanchego to find it - fixing the Docker build

## How this works
Avalanchego by default looks for subnet binaries within the plugins folder based on the subnet ID of the given subnet. Each subnet should be in a subfolder named based on the subnet ID. `srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy` is the default subnet ID for this repo. `o1Fg94YukvVRijwyThAavybVfwVJH3dhyz94g6qYRGdQ5Arqp` is the correct subnet ID for Hubblenet.

## How this was tested
I am currently running Hubblenet via a Docker image based on this exact Dockerfile.

## How is this documented
The standard Docker build instructions for the repo should now just automagically work.