### PR TITLE
Fix snapshot logic and add GetSnapshot API

### DIFF
--- a/chain.json
+++ b/chain.json
@@ -8,5 +8,6 @@
   "priority-regossip-addresses": ["0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", "0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC", "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"],
   "validator-private-key-file": "/tmp/validator.pk",
   "is-validator": true,
-  "trading-api-enabled": true
+  "trading-api-enabled": true,
+  "testing-api-enabled": true
 }

--- a/chain.json
+++ b/chain.json
@@ -9,5 +9,6 @@
   "validator-private-key-file": "/tmp/validator.pk",
   "is-validator": true,
   "trading-api-enabled": true,
-  "testing-api-enabled": true
+  "testing-api-enabled": true,
+  "load-from-snapshot-enabled": true
 }

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1080,6 +1080,9 @@ func (pool *TxPool) GetOrderBookTxNonce(address common.Address) uint64 {
 }
 
 func (pool *TxPool) AddOrderBookTx(tx *types.Transaction) error {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
 	if from, err := types.Sender(pool.signer, tx); err == nil {
 		val, ok := pool.OrderBookTxMap[from]
 		if !ok {
@@ -1090,6 +1093,8 @@ func (pool *TxPool) AddOrderBookTx(tx *types.Transaction) error {
 		if !ok {
 			return errors.New("error adding tx to orderbookQueue")
 		}
+	} else {
+		return fmt.Errorf("AddOrderBookTx: error getting sender: %w", err)
 	}
 	return nil
 }

--- a/networks/hubblenext/chain.json
+++ b/networks/hubblenext/chain.json
@@ -9,5 +9,6 @@
   "validator-private-key-file": "/home/ubuntu/validator.pk",
   "feeRecipient": "0x393bd9ac9dbBe75e84db739Bb15d22cA86D26696",
   "is-validator": true,
-  "trading-api-enabled": false
+  "trading-api-enabled": false,
+  "load-from-snapshot-enabled": true
 }

--- a/networks/hubblenext/chain_api_node.json
+++ b/networks/hubblenext/chain_api_node.json
@@ -12,6 +12,6 @@
     "validator-private-key-file": "/home/ubuntu/validator.pk",
     "feeRecipient": "0x93ec352b9eDe4e4515b24945E37186c462a2D583",
     "is-validator": false,
-    "trading-api-enabled": true
-  
+    "trading-api-enabled": true,
+    "load-from-snapshot-enabled": true
 }

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -59,8 +59,9 @@ const (
 	defaultStateSyncMinBlocks   = 300_000
 	defaultStateSyncRequestSize = 1024 // the number of key/values to ask peers for per request
 
-	defaultIsValidator       = false
-	defaultTradingAPIEnabled = false
+	defaultIsValidator             = false
+	defaultTradingAPIEnabled       = false
+	defaultLoadFromSnapshotEnabled = true
 )
 
 var (
@@ -225,6 +226,9 @@ type Config struct {
 
 	// TradingAPI is for the sdk
 	TradingAPIEnabled bool `json:"trading-api-enabled"`
+
+	// LoadFromSnapshotEnabled = true if the node should load the memory db from a snapshot
+	LoadFromSnapshotEnabled bool `json:"load-from-snapshot-enabled"`
 }
 
 // EthAPIs returns an array of strings representing the Eth APIs that should be enabled
@@ -287,6 +291,7 @@ func (c *Config) SetDefaults() {
 	c.TestingApiEnabled = defaultTestingApiEnabled
 	c.IsValidator = defaultIsValidator
 	c.TradingAPIEnabled = defaultTradingAPIEnabled
+	c.LoadFromSnapshotEnabled = defaultLoadFromSnapshotEnabled
 }
 
 func (d *Duration) UnmarshalJSON(data []byte) (err error) {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -218,6 +218,9 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 					blockNumber := logs[0].BlockNumber
 					block := lop.blockChain.GetBlockByHash(logs[0].BlockHash)
 
+					// If n is the block at which snapshot should be saved(n is multiple of [snapshotInterval]), save the snapshot
+					// when logs of block number >= n + 1 are received before applying them in memory db
+
 					blockNumberFloor := ((blockNumber - 1) / snapshotInterval) * snapshotInterval
 					if blockNumberFloor > lop.snapshotSavedBlockNumber {
 						lop.memoryDb.Accept(blockNumberFloor, block.Timestamp())

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -100,19 +100,19 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions(blockBuilder *block
 	if lastAcceptedBlockNumber.Sign() > 0 {
 		fromBlock := big.NewInt(0)
 
-		// first load the last snapshot containing finalised data till block x and query the logs of [x+1, latest]
-		acceptedBlockNumber, err := lop.loadMemoryDBSnapshot()
-		if err != nil {
-			log.Error("ListenAndProcessTransactions - error in loading snapshot", "err", err)
-		} else {
-			if acceptedBlockNumber > 0 {
-				fromBlock = big.NewInt(int64(acceptedBlockNumber) + 1)
-				log.Info("ListenAndProcessTransactions - memory DB snapshot loaded", "acceptedBlockNumber", acceptedBlockNumber)
-			} else {
-				// not an error, but unlikely after the blockchain is running for some time
-				log.Warn("ListenAndProcessTransactions - no snapshot found")
-			}
-		}
+		// // first load the last snapshot containing finalised data till block x and query the logs of [x+1, latest]
+		// acceptedBlockNumber, err := lop.loadMemoryDBSnapshot()
+		// if err != nil {
+		// 	log.Error("ListenAndProcessTransactions - error in loading snapshot", "err", err)
+		// } else {
+		// 	if acceptedBlockNumber > 0 {
+		// 		fromBlock = big.NewInt(int64(acceptedBlockNumber) + 1)
+		// 		log.Info("ListenAndProcessTransactions - memory DB snapshot loaded", "acceptedBlockNumber", acceptedBlockNumber)
+		// 	} else {
+		// 		// not an error, but unlikely after the blockchain is running for some time
+		// 		log.Warn("ListenAndProcessTransactions - no snapshot found")
+		// 	}
+		// }
 
 		logHandler := log.Root().GetHandler()
 		log.Info("ListenAndProcessTransactions - beginning sync", " till block number", lastAcceptedBlockNumber)

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -420,7 +420,7 @@ const (
 	ConfirmationLevelAccepted BlockConfirmationLevel = "accepted"
 )
 
-func (cep *ContractEventsProcessor) PushtoTraderFeed(events []*types.Log, blockStatus BlockConfirmationLevel) {
+func (cep *ContractEventsProcessor) PushToTraderFeed(events []*types.Log, blockStatus BlockConfirmationLevel) {
 	for _, event := range events {
 		removed := event.Removed
 		args := map[string]interface{}{}

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -313,7 +313,6 @@ func (lotp *limitOrderTxProcessor) UpdateMetrics(block *types.Block) {
 				counterName := fmt.Sprintf("orderbooktxs/%s/%s", method.Name, note)
 				metrics.GetOrRegisterCounter(counterName, nil).Inc(1)
 			}
-
 		}
 
 		// measure the gas usage irrespective of whether the tx is from this validator or not

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1047,8 +1047,7 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 		vm.blockChain,
 		vm.hubbleDB,
 		validatorPrivateKey,
-		vm.config.IsValidator,
-		vm.config.TradingAPIEnabled,
+		vm.config,
 	)
 }
 


### PR DESCRIPTION
## Why this should be merged
Fixes the logic for saving memory database snapshots. The snapshots was sometimes saved before events were applied for that block. It fixes the issue by saving the snapshot in AcceptedLogs handler. If n is the block at which snapshot should be saved, it saves the snapshot when logs of block number >= n + 1 are received before applying them in memory db.

## How this was tested
On local

## How is this documented
