### PR TITLE
MemoryDB State Fixes

### DIFF
--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -418,7 +418,7 @@ func (lop *limitOrderProcesser) getLogs(fromBlock, toBlock *big.Int) []*types.Lo
 	return logs
 }
 
-func (lop *limitOrderProcesser) UpdateLastPremiumFractionFromStorage(blockNumber uint64) {
+func (lop *limitOrderProcesser) UpdateLastPremiumFractionFromStorage() {
 	traderMap := lop.memoryDb.GetOrderBookData().TraderMap
 	count := 0
 	start := time.Now()

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -121,13 +121,14 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions(blockBuilder *block
 		}
 
 		logHandler := log.Root().GetHandler()
+		errorOnlyHandler := ErrorOnlyHandler(logHandler)
 		log.Info("ListenAndProcessTransactions - beginning sync", " till block number", lastAcceptedBlockNumber)
 		JUMP := big.NewInt(3999)
 		toBlock := utils.BigIntMin(lastAcceptedBlockNumber, big.NewInt(0).Add(fromBlock, JUMP))
 		for toBlock.Cmp(fromBlock) > 0 {
 			logs := lop.getLogs(fromBlock, toBlock)
 			// set the log handler to discard logs so that the ProcessEvents doesn't spam the logs
-			log.Root().SetHandler(log.DiscardHandler())
+			log.Root().SetHandler(errorOnlyHandler)
 			lop.contractEventProcessor.ProcessEvents(logs)
 			lop.contractEventProcessor.ProcessAcceptedEvents(logs, true)
 			lop.memoryDb.Accept(toBlock.Uint64(), 0) // will delete stale orders from the memorydb

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -143,7 +143,7 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions(blockBuilder *block
 		log.Root().SetHandler(logHandler)
 
 		// needs to be run everytime as long as the db.UpdatePosition uses configService.GetCumulativePremiumFraction
-		lop.UpdateLastPremiumFractionFromStorage(lastAcceptedBlockNumber.Uint64())
+		// lop.UpdateLastPremiumFractionFromStorage(lastAcceptedBlockNumber.Uint64())
 	}
 
 	lop.mu.Unlock()

--- a/plugin/evm/log.go
+++ b/plugin/evm/log.go
@@ -127,6 +127,16 @@ func HubbleErrorHandler(h log.Handler) log.Handler {
 	})
 }
 
+func ErrorOnlyHandler(h log.Handler) log.Handler {
+	// ignores all logs except lvl=error
+	return log.FuncHandler(func(r *log.Record) error {
+		if r.Lvl == log.LvlError {
+			return h.Log(r)
+		}
+		return nil
+	})
+}
+
 func formatJSONValue(value interface{}) (result interface{}) {
 	defer func() {
 		if err := recover(); err != nil {

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -69,7 +69,10 @@ func (cs *ConfigService) getStateAtCurrentBlock() *state.StateDB {
 }
 
 func (cs *ConfigService) getStateAtBlock(number uint64) *state.StateDB {
-	stateDB, _ := cs.blockChain.StateAt(cs.blockChain.GetHeaderByNumber(number).Root)
+	stateDB, err := cs.blockChain.StateAt(cs.blockChain.GetHeaderByNumber(number).Root)
+	if err != nil {
+		panic(err)
+	}
 	return stateDB
 }
 

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -18,7 +18,9 @@ type IConfigService interface {
 	GetActiveMarketsCount() int64
 	GetUnderlyingPrices() []*big.Int
 	GetLastPremiumFraction(market Market, trader *common.Address) *big.Int
+	GetLastPremiumFractionAtBlock(market Market, trader *common.Address, blockNumber uint64) *big.Int
 	GetCumulativePremiumFraction(market Market) *big.Int
+	GetCumulativePremiumFractionAtBlock(market Market, blockNumber uint64) *big.Int
 	GetAcceptableBounds(market Market) (*big.Int, *big.Int)
 	GetAcceptableBoundsForLiquidation(market Market) (*big.Int, *big.Int)
 }
@@ -66,6 +68,11 @@ func (cs *ConfigService) getStateAtCurrentBlock() *state.StateDB {
 	return stateDB
 }
 
+func (cs *ConfigService) getStateAtBlock(number uint64) *state.StateDB {
+	stateDB, _ := cs.blockChain.StateAt(cs.blockChain.GetHeaderByNumber(number).Root)
+	return stateDB
+}
+
 func (cs *ConfigService) GetActiveMarketsCount() int64 {
 	return bibliophile.GetActiveMarketsCount(cs.getStateAtCurrentBlock())
 }
@@ -79,7 +86,19 @@ func (cs *ConfigService) GetLastPremiumFraction(market Market, trader *common.Ad
 	return bibliophile.GetLastPremiumFraction(cs.getStateAtCurrentBlock(), markets[market], trader)
 }
 
+func (cs *ConfigService) GetLastPremiumFractionAtBlock(market Market, trader *common.Address, number uint64) *big.Int {
+	state := cs.getStateAtBlock(number)
+	markets := bibliophile.GetMarkets(state)
+	return bibliophile.GetLastPremiumFraction(state, markets[market], trader)
+}
+
 func (cs *ConfigService) GetCumulativePremiumFraction(market Market) *big.Int {
 	markets := bibliophile.GetMarkets(cs.getStateAtCurrentBlock())
 	return bibliophile.GetCumulativePremiumFraction(cs.getStateAtCurrentBlock(), markets[market])
+}
+
+func (cs *ConfigService) GetCumulativePremiumFractionAtBlock(market Market, number uint64) *big.Int {
+	state := cs.getStateAtBlock(number)
+	markets := bibliophile.GetMarkets(state)
+	return bibliophile.GetCumulativePremiumFraction(state, markets[market])
 }

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -18,9 +18,7 @@ type IConfigService interface {
 	GetActiveMarketsCount() int64
 	GetUnderlyingPrices() []*big.Int
 	GetLastPremiumFraction(market Market, trader *common.Address) *big.Int
-	GetLastPremiumFractionAtBlock(market Market, trader *common.Address, blockNumber uint64) *big.Int
 	GetCumulativePremiumFraction(market Market) *big.Int
-	GetCumulativePremiumFractionAtBlock(market Market, blockNumber uint64) *big.Int
 	GetAcceptableBounds(market Market) (*big.Int, *big.Int)
 	GetAcceptableBoundsForLiquidation(market Market) (*big.Int, *big.Int)
 }
@@ -89,19 +87,7 @@ func (cs *ConfigService) GetLastPremiumFraction(market Market, trader *common.Ad
 	return bibliophile.GetLastPremiumFraction(cs.getStateAtCurrentBlock(), markets[market], trader)
 }
 
-func (cs *ConfigService) GetLastPremiumFractionAtBlock(market Market, trader *common.Address, number uint64) *big.Int {
-	state := cs.getStateAtBlock(number)
-	markets := bibliophile.GetMarkets(state)
-	return bibliophile.GetLastPremiumFraction(state, markets[market], trader)
-}
-
 func (cs *ConfigService) GetCumulativePremiumFraction(market Market) *big.Int {
 	markets := bibliophile.GetMarkets(cs.getStateAtCurrentBlock())
 	return bibliophile.GetCumulativePremiumFraction(cs.getStateAtCurrentBlock(), markets[market])
-}
-
-func (cs *ConfigService) GetCumulativePremiumFractionAtBlock(market Market, number uint64) *big.Int {
-	state := cs.getStateAtBlock(number)
-	markets := bibliophile.GetMarkets(state)
-	return bibliophile.GetCumulativePremiumFraction(state, markets[market])
 }

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -367,7 +367,7 @@ func (cep *ContractEventsProcessor) handleClearingHouseEvent(event *types.Log) {
 		openNotional := args["openNotional"].(*big.Int)
 		size := args["size"].(*big.Int)
 		log.Info("PositionModified", "trader", trader, "market", market, "args", args)
-		cep.database.UpdatePosition(trader, market, size, openNotional, false)
+		cep.database.UpdatePosition(trader, market, size, openNotional, false, event.BlockNumber)
 	case cep.clearingHouseABI.Events["PositionLiquidated"].ID:
 		err := cep.clearingHouseABI.UnpackIntoMap(args, "PositionLiquidated", event.Data)
 		if err != nil {
@@ -383,7 +383,7 @@ func (cep *ContractEventsProcessor) handleClearingHouseEvent(event *types.Log) {
 		openNotional := args["openNotional"].(*big.Int)
 		size := args["size"].(*big.Int)
 		log.Info("PositionLiquidated", "market", market, "trader", trader, "args", args)
-		cep.database.UpdatePosition(trader, market, size, openNotional, true)
+		cep.database.UpdatePosition(trader, market, size, openNotional, true, event.BlockNumber)
 	}
 }
 

--- a/plugin/evm/orderbook/liquidations.go
+++ b/plugin/evm/orderbook/liquidations.go
@@ -24,16 +24,6 @@ func (liq LiquidablePosition) GetUnfilledSize() *big.Int {
 	return big.NewInt(0).Sub(liq.Size, liq.FilledSize)
 }
 
-// returns the max(oracle_mf, last_mf); hence should only be used to determine the margin fraction for liquidation and not to increase leverage
-func calcMarginFractionWithDebugInfo(addr common.Address, trader *Trader, pendingFunding *big.Int, oraclePrices map[Market]*big.Int, lastPrices map[Market]*big.Int, markets []Market) *big.Int {
-	// for debugging
-	// if strings.EqualFold(addr.String(), "917251b02D43372A083b75890dF33Bf6d2bD0e02") {
-	// 	log.Info("calcMarginFraction:M", "pendingFunding", pendingFunding, "margin", margin, "notionalPosition", notionalPosition, "unrealizePnL", unrealizePnL)
-	// }
-	// log.Info("calcMarginFraction", "margin", margin, "notionalPosition", notionalPosition)
-	return calcMarginFraction(trader, pendingFunding, oraclePrices, lastPrices, markets)
-}
-
 func calcMarginFraction(trader *Trader, pendingFunding *big.Int, oraclePrices map[Market]*big.Int, lastPrices map[Market]*big.Int, markets []Market) *big.Int {
 	margin := new(big.Int).Sub(getNormalisedMargin(trader), pendingFunding)
 	notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(trader, margin, Maintenance_Margin, oraclePrices, lastPrices, markets)

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ava-labs/subnet-evm/metrics"
 	"github.com/ava-labs/subnet-evm/utils"
@@ -424,6 +425,11 @@ func (db *InMemoryDatabase) getCleanOrder(order *Order, blockNumber *big.Int) *O
 				log.Warn("eligible order is in Execution_Failed state", "orderId", order.String(), "retryInBlocks", orderStatus.BlockNumber+RETRY_AFTER_BLOCKS-blockNumber.Uint64())
 			}
 		}
+	}
+
+	expireAt := order.getExpireAt()
+	if expireAt.Sign() == 1 && expireAt.Int64() <= time.Now().Unix() {
+		eligibleForExecution = false
 	}
 
 	if eligibleForExecution {

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -556,10 +556,7 @@ func TestUpdateUnrealizedFunding(t *testing.T) {
 			newCumulativePremiumFraction := big.NewInt(5)
 			inMemoryDatabase.UpdateUnrealisedFunding(market, newCumulativePremiumFraction)
 			for _, address := range addresses {
-				unrealizedFunding := inMemoryDatabase.TraderMap[address].Positions[market].UnrealisedFunding
-				size := inMemoryDatabase.TraderMap[address].Positions[market].Size
-				expectedUnrealizedFunding := big.NewInt(0).Div(big.NewInt(0).Mul(big.NewInt(0).Sub(newCumulativePremiumFraction, cumulativePremiumFraction), size), SIZE_BASE_PRECISION)
-				assert.Equal(t, expectedUnrealizedFunding, unrealizedFunding)
+				assert.Equal(t, uint64(0), inMemoryDatabase.TraderMap[address].Positions[market].UnrealisedFunding.Uint64())
 			}
 		})
 		t.Run("when unrealized funding is not zero, it adds new funding to old unrealized funding in trader's positions", func(t *testing.T) {
@@ -575,7 +572,7 @@ func TestUpdateUnrealizedFunding(t *testing.T) {
 			newCumulativePremiumFraction := big.NewInt(-1)
 			inMemoryDatabase.UpdateUnrealisedFunding(market, newCumulativePremiumFraction)
 			newUnrealizedFunding := inMemoryDatabase.TraderMap[address].Positions[market].UnrealisedFunding
-			expectedUnrealizedFunding := big.NewInt(0).Div(big.NewInt(0).Mul(big.NewInt(0).Sub(newCumulativePremiumFraction, cumulativePremiumFraction), size), SIZE_BASE_PRECISION)
+			expectedUnrealizedFunding := calcPendingFunding(newCumulativePremiumFraction, cumulativePremiumFraction, size)
 			assert.Equal(t, expectedUnrealizedFunding, newUnrealizedFunding)
 		})
 	})

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -120,9 +120,8 @@ func TestGetShortOrders(t *testing.T) {
 	assert.Equal(t, blockNumber1, returnedShortOrders[2].BlockNumber)
 
 	// now test with one reduceOnly order when there's a long position
-
 	size := big.NewInt(0).Mul(big.NewInt(2), _1e18)
-	inMemoryDatabase.UpdatePosition(trader, market, size, big.NewInt(0).Mul(big.NewInt(100), _1e6), false)
+	inMemoryDatabase.UpdatePosition(trader, market, size, big.NewInt(0).Mul(big.NewInt(100), _1e6), false, 0)
 
 	returnedShortOrders = inMemoryDatabase.GetShortOrders(market, nil, nil)
 	assert.Equal(t, 4, len(returnedShortOrders))
@@ -241,7 +240,7 @@ func TestGetCancellableOrders(t *testing.T) {
 	// 1 fulfilled order at price = 10, size = 9
 	size := big.NewInt(0).Mul(big.NewInt(-9), _1e18)
 	fulfilPrice := multiplyBasePrecision(big.NewInt(10))
-	inMemoryDatabase.UpdatePosition(trader, market, size, dividePrecisionSize(new(big.Int).Mul(new(big.Int).Abs(size), fulfilPrice)), false)
+	inMemoryDatabase.UpdatePosition(trader, market, size, dividePrecisionSize(new(big.Int).Mul(new(big.Int).Abs(size), fulfilPrice)), false, 0)
 	inMemoryDatabase.UpdateLastPrice(market, fulfilPrice)
 
 	// price has moved from 10 to 11 now
@@ -372,7 +371,7 @@ func TestUpdatePosition(t *testing.T) {
 		var market Market = 1
 		size := big.NewInt(20.00)
 		openNotional := big.NewInt(200.00)
-		inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false)
+		inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false, 0)
 		position := inMemoryDatabase.TraderMap[address].Positions[market]
 		assert.Equal(t, size, position.Size)
 		assert.Equal(t, openNotional, position.OpenNotional)
@@ -383,11 +382,11 @@ func TestUpdatePosition(t *testing.T) {
 		var market Market = 1
 		size := big.NewInt(20.00)
 		openNotional := big.NewInt(200.00)
-		inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false)
+		inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false, 0)
 
 		newSize := big.NewInt(25.00)
 		newOpenNotional := big.NewInt(250.00)
-		inMemoryDatabase.UpdatePosition(address, market, newSize, newOpenNotional, false)
+		inMemoryDatabase.UpdatePosition(address, market, newSize, newOpenNotional, false, 0)
 		position := inMemoryDatabase.TraderMap[address].Positions[market]
 		assert.Equal(t, newSize, position.Size)
 		assert.Equal(t, newOpenNotional, position.OpenNotional)
@@ -551,7 +550,7 @@ func TestUpdateUnrealizedFunding(t *testing.T) {
 			for i, address := range addresses {
 				iterator := i + 1
 				size := big.NewInt(int64(20 * iterator))
-				inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false)
+				inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false, 0)
 				inMemoryDatabase.ResetUnrealisedFunding(market, address, cumulativePremiumFraction)
 			}
 			newCumulativePremiumFraction := big.NewInt(5)
@@ -569,7 +568,7 @@ func TestUpdateUnrealizedFunding(t *testing.T) {
 			var market Market = 1
 			openNotional := big.NewInt(200.00)
 			size := big.NewInt(20.00)
-			inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false)
+			inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false, 0)
 			cumulativePremiumFraction := big.NewInt(2)
 			inMemoryDatabase.ResetUnrealisedFunding(market, address, cumulativePremiumFraction)
 
@@ -599,7 +598,7 @@ func TestResetUnrealisedFunding(t *testing.T) {
 		var market Market = 1
 		openNotional := big.NewInt(200)
 		size := big.NewInt(20)
-		inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false)
+		inMemoryDatabase.UpdatePosition(address, market, size, openNotional, false, 0)
 		cumulativePremiumFraction := big.NewInt(1)
 		inMemoryDatabase.ResetUnrealisedFunding(market, address, cumulativePremiumFraction)
 		unrealizedFundingFee := inMemoryDatabase.TraderMap[address].Positions[market].UnrealisedFunding

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -51,7 +51,7 @@ func (db *MockLimitOrderDatabase) GetShortOrders(market Market, upperbound *big.
 	return args.Get(0).([]Order)
 }
 
-func (db *MockLimitOrderDatabase) UpdatePosition(trader common.Address, market Market, size *big.Int, openNotional *big.Int, isLiquidation bool) {
+func (db *MockLimitOrderDatabase) UpdatePosition(trader common.Address, market Market, size *big.Int, openNotional *big.Int, isLiquidation bool, blockNumber uint64) {
 }
 
 func (db *MockLimitOrderDatabase) UpdateMargin(trader common.Address, collateral Collateral, addAmount *big.Int) {
@@ -246,7 +246,15 @@ func (cs *MockConfigService) GetLastPremiumFraction(market Market, trader *commo
 	return big.NewInt(0)
 }
 
+func (cs *MockConfigService) GetLastPremiumFractionAtBlock(market Market, trader *common.Address, blockNumber uint64) *big.Int {
+	return big.NewInt(0)
+}
+
 func (cs *MockConfigService) GetCumulativePremiumFraction(market Market) *big.Int {
+	return big.NewInt(0)
+}
+
+func (cs *MockConfigService) GetCumulativePremiumFractionAtBlock(market Market, blockNumber uint64) *big.Int {
 	return big.NewInt(0)
 }
 

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -310,7 +310,10 @@ func (lotp *limitOrderTxProcessor) UpdateMetrics(block *types.Block) {
 			if contractAddress != nil && lotp.orderBookContractAddress == *contractAddress {
 				note := "success"
 				if receipt.Status == 0 {
-					log.Error("orderbook tx failed", "method", method.Name, "tx", tx.Hash().String(), "receipt", receipt)
+					log.Error("orderbook tx failed", "method", method.Name, "tx", tx.Hash().String(),
+						"receipt.Status", receipt.Status, "receipt.CumulativeGasUsed", receipt.CumulativeGasUsed,
+						"receipt.GasUsed", receipt.GasUsed, "receipt.EffectiveGasPrice", receipt.EffectiveGasPrice,
+						"receipt.BlockNumber", receipt.BlockNumber)
 					note = "failure"
 				}
 				counterName := fmt.Sprintf("orderbooktxs/%s/%s", method.Name, note)

--- a/precompile/contracts/juror/contract.go
+++ b/precompile/contracts/juror/contract.go
@@ -193,10 +193,7 @@ func validateOrdersAndDetermineFillPrice(accessibleState contract.AccessibleStat
 	bibliophile := bibliophile.NewBibliophileClient(accessibleState)
 	output, err := ValidateOrdersAndDetermineFillPrice(bibliophile, &inputStruct)
 	if err != nil {
-		log.Error("validateOrdersAndDetermineFillPrice", "error", err, "block", accessibleState.GetBlockContext().Number())
-		if !errors.Is(err, ErrTwoOrders) {
-			log.Error("debug-info", "order0", formatOrder(inputStruct.Data[0]), "order1", formatOrder(inputStruct.Data[1]), "fillAmount", inputStruct.FillAmount, "err", err)
-		}
+		log.Error("validateOrdersAndDetermineFillPrice", "order0", formatOrder(inputStruct.Data[0]), "order1", formatOrder(inputStruct.Data[1]), "fillAmount", inputStruct.FillAmount, "err", err, "block", accessibleState.GetBlockContext().Number())
 		return nil, remainingGas, err
 	}
 	packedOutput, err := PackValidateOrdersAndDetermineFillPriceOutput(*output)

--- a/precompile/contracts/juror/logic.go
+++ b/precompile/contracts/juror/logic.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ava-labs/subnet-evm/plugin/evm/orderbook"
 	b "github.com/ava-labs/subnet-evm/precompile/contracts/bibliophile"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 type OrderType uint8
@@ -294,7 +293,6 @@ func validateLimitOrderLike(bibliophile b.BibliophileClient, order *orderbook.Li
 
 // IOC Orders
 func ValidatePlaceIOCOrders(bibliophile b.BibliophileClient, inputStruct *ValidatePlaceIOCOrdersInput) (orderHashes [][32]byte, err error) {
-	log.Info("ValidatePlaceIOCOrders", "input", inputStruct)
 	orders := inputStruct.Orders
 	if len(orders) == 0 {
 		return nil, errors.New("no orders")
@@ -319,7 +317,6 @@ func ValidatePlaceIOCOrders(bibliophile b.BibliophileClient, inputStruct *Valida
 		if order.ExpireAt.Uint64() < blockTimestamp {
 			return nil, errors.New("ioc expired")
 		}
-		log.Info("ValidatePlaceIOCOrders", "order.ExpireAt", order.ExpireAt.Uint64(), "expireWithin", expireWithin)
 		if order.ExpireAt.Uint64() > expireWithin {
 			return nil, errors.New("ioc expiration too far")
 		}


### PR DESCRIPTION
## Why this should be merged
- Event application was slightly error-prone for `LastPremiumFraction` field
- Store `CumulativePremiumFraction` in memory
- :bug: in recovery from snapshot
- Skip expired IOC orders in matching
- Logging improvements
