### PR TITLE
New events for OrderV2

### DIFF
--- a/plugin/evm/orderbook/abis/ClearingHouse.go
+++ b/plugin/evm/orderbook/abis/ClearingHouse.go
@@ -104,6 +104,19 @@ var ClearingHouseAbi = []byte(`{"abi": [
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "address",
         "name": "trader",
@@ -214,7 +227,7 @@ var ClearingHouseAbi = []byte(`{"abi": [
       },
       {
         "indexed": false,
-        "internalType": "enum IOrderBook.OrderExecutionMode",
+        "internalType": "enum IClearingHouse.OrderExecutionMode",
         "name": "mode",
         "type": "uint8"
       },
@@ -248,10 +261,49 @@ var ClearingHouseAbi = []byte(`{"abi": [
     "type": "event"
   },
   {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "nextSampleTime",
+        "type": "uint256"
+      }
+    ],
+    "name": "SamplePI",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "LIQUIDATION_FAILED",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "idx",
+        "name": "",
         "type": "uint256"
       }
     ],
@@ -276,6 +328,19 @@ var ClearingHouseAbi = []byte(`{"abi": [
     ],
     "name": "assertMarginRequirement",
     "outputs": [],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bibliophile",
+    "outputs": [
+      {
+        "internalType": "contract IHubbleBibliophile",
+        "name": "",
+        "type": "address"
+      }
+    ],
     "stateMutability": "view",
     "type": "function"
   },
@@ -310,12 +375,38 @@ var ClearingHouseAbi = []byte(`{"abi": [
   },
   {
     "inputs": [],
+    "name": "defaultOrderBook",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "feeSink",
     "outputs": [
       {
         "internalType": "address",
         "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAMMs",
+    "outputs": [
+      {
+        "internalType": "contract IAMM[]",
+        "name": "",
+        "type": "address[]"
       }
     ],
     "stateMutability": "view",
@@ -353,6 +444,40 @@ var ClearingHouseAbi = []byte(`{"abi": [
       }
     ],
     "name": "getNotionalPositionAndMargin",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "notionalPosition",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "margin",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "includeFundingPayments",
+        "type": "bool"
+      },
+      {
+        "internalType": "enum IClearingHouse.Mode",
+        "name": "mode",
+        "type": "uint8"
+      }
+    ],
+    "name": "getNotionalPositionAndMarginVanilla",
     "outputs": [
       {
         "internalType": "uint256",
@@ -435,6 +560,70 @@ var ClearingHouseAbi = []byte(`{"abi": [
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "governance",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "hubbleReferral",
+    "outputs": [
+      {
+        "internalType": "contract IHubbleReferral",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_governance",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_feeSink",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_marginAccount",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_defaultOrderBook",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_vusd",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_hubbleReferral",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -456,6 +645,57 @@ var ClearingHouseAbi = []byte(`{"abi": [
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "isWhitelistedOrderBook",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "lastFundingPaid",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "lastFundingTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "components": [
           {
             "internalType": "uint256",
@@ -468,50 +708,18 @@ var ClearingHouseAbi = []byte(`{"abi": [
             "type": "address"
           },
           {
-            "internalType": "int256",
-            "name": "baseAssetQuantity",
-            "type": "int256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "price",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "salt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "reduceOnly",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct IOrderBook.Order",
-        "name": "order",
-        "type": "tuple"
-      },
-      {
-        "components": [
-          {
             "internalType": "bytes32",
             "name": "orderHash",
             "type": "bytes32"
           },
           {
-            "internalType": "uint256",
-            "name": "blockPlaced",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum IOrderBook.OrderExecutionMode",
+            "internalType": "enum IClearingHouse.OrderExecutionMode",
             "name": "mode",
             "type": "uint8"
           }
         ],
-        "internalType": "struct IOrderBook.MatchInfo",
-        "name": "matchInfo",
+        "internalType": "struct IClearingHouse.Instruction",
+        "name": "instruction",
         "type": "tuple"
       },
       {
@@ -531,6 +739,40 @@ var ClearingHouseAbi = []byte(`{"abi": [
       }
     ],
     "name": "liquidate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "openInterest",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "ammIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "toLiquidate",
+        "type": "int256"
+      }
+    ],
+    "name": "liquidateSingleAmm",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -576,12 +818,38 @@ var ClearingHouseAbi = []byte(`{"abi": [
   },
   {
     "inputs": [],
+    "name": "marginAccount",
+    "outputs": [
+      {
+        "internalType": "contract IMarginAccount",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
     "name": "minAllowableMargin",
     "outputs": [
       {
         "internalType": "int256",
         "name": "",
         "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nextSampleTime",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -602,50 +870,18 @@ var ClearingHouseAbi = []byte(`{"abi": [
             "type": "address"
           },
           {
-            "internalType": "int256",
-            "name": "baseAssetQuantity",
-            "type": "int256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "price",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "salt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "reduceOnly",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct IOrderBook.Order[2]",
-        "name": "orders",
-        "type": "tuple[2]"
-      },
-      {
-        "components": [
-          {
             "internalType": "bytes32",
             "name": "orderHash",
             "type": "bytes32"
           },
           {
-            "internalType": "uint256",
-            "name": "blockPlaced",
-            "type": "uint256"
-          },
-          {
-            "internalType": "enum IOrderBook.OrderExecutionMode",
+            "internalType": "enum IClearingHouse.OrderExecutionMode",
             "name": "mode",
             "type": "uint8"
           }
         ],
-        "internalType": "struct IOrderBook.MatchInfo[2]",
-        "name": "matchInfo",
+        "internalType": "struct IClearingHouse.Instruction[2]",
+        "name": "orders",
         "type": "tuple[2]"
       },
       {
@@ -660,7 +896,69 @@ var ClearingHouseAbi = []byte(`{"abi": [
       }
     ],
     "name": "openComplementaryPositions",
-    "outputs": [],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "openInterest",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "ammIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "trader",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "orderHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum IClearingHouse.OrderExecutionMode",
+            "name": "mode",
+            "type": "uint8"
+          }
+        ],
+        "internalType": "struct IClearingHouse.Instruction",
+        "name": "order",
+        "type": "tuple"
+      },
+      {
+        "internalType": "int256",
+        "name": "fillAmount",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fulfillPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bool",
+        "name": "is2ndTrade",
+        "type": "bool"
+      }
+    ],
+    "name": "openPosition",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "openInterest",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -669,12 +967,165 @@ var ClearingHouseAbi = []byte(`{"abi": [
     "name": "orderBook",
     "outputs": [
       {
-        "internalType": "contract IOrderBook",
+        "internalType": "address",
         "name": "",
         "type": "address"
       }
     ],
     "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "referralShare",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "samplePI",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_bibliophile",
+        "type": "address"
+      }
+    ],
+    "name": "setBibliophile",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_feeSink",
+        "type": "address"
+      }
+    ],
+    "name": "setFeeSink",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "__governance",
+        "type": "address"
+      }
+    ],
+    "name": "setGovernace",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_orderBook",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "_status",
+        "type": "bool"
+      }
+    ],
+    "name": "setOrderBookWhitelist",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "_maintenanceMargin",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "_minAllowableMargin",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "_takerFee",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "_makerFee",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_referralShare",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_tradingFeeDiscount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_liquidationPenalty",
+        "type": "uint256"
+      }
+    ],
+    "name": "setParams",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_referral",
+        "type": "address"
+      }
+    ],
+    "name": "setReferral",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -698,6 +1149,26 @@ var ClearingHouseAbi = []byte(`{"abi": [
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "tradingFeeDiscount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -706,6 +1177,32 @@ var ClearingHouseAbi = []byte(`{"abi": [
       }
     ],
     "name": "updatePositions",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "vusd",
+    "outputs": [
+      {
+        "internalType": "contract VUSD",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_amm",
+        "type": "address"
+      }
+    ],
+    "name": "whitelistAmm",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/plugin/evm/orderbook/abis/OrderBook.go
+++ b/plugin/evm/orderbook/abis/OrderBook.go
@@ -2,6 +2,35 @@ package abis
 
 var OrderBookAbi = []byte(`{"abi": [
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_clearingHouse",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_marginAccount",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {
@@ -79,6 +108,130 @@ var OrderBookAbi = []byte(`{"abi": [
       }
     ],
     "name": "LiquidationOrderMatched",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "ammIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "trader",
+            "type": "address"
+          },
+          {
+            "internalType": "int256",
+            "name": "baseAssetQuantity",
+            "type": "int256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "reduceOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "postOnly",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ILimitOrderBook.OrderV2",
+        "name": "order",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "OrderAccepted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "OrderCancelAccepted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "err",
+        "type": "string"
+      }
+    ],
+    "name": "OrderCancelRejected",
     "type": "event"
   },
   {
@@ -236,6 +389,80 @@ var OrderBookAbi = []byte(`{"abi": [
     "inputs": [
       {
         "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "ammIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "trader",
+            "type": "address"
+          },
+          {
+            "internalType": "int256",
+            "name": "baseAssetQuantity",
+            "type": "int256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "reduceOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "postOnly",
+            "type": "bool"
+          }
+        ],
+        "indexed": false,
+        "internalType": "struct ILimitOrderBook.OrderV2",
+        "name": "order",
+        "type": "tuple"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "err",
+        "type": "string"
+      }
+    ],
+    "name": "OrderRejected",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
         "internalType": "bytes32",
         "name": "orderHash0",
         "type": "bytes32"
@@ -281,48 +508,136 @@ var OrderBookAbi = []byte(`{"abi": [
     "type": "event"
   },
   {
+    "anonymous": false,
     "inputs": [
       {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "ammIndex",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "trader",
-            "type": "address"
-          },
-          {
-            "internalType": "int256",
-            "name": "baseAssetQuantity",
-            "type": "int256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "price",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "salt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "reduceOnly",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct ILimitOrderBook.Order",
-        "name": "order",
-        "type": "tuple"
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
       }
     ],
-    "name": "cancelOrder",
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "name": "SkippedCancelOrder",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "authority",
+        "type": "address"
+      }
+    ],
+    "name": "TradingAuthorityRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "authority",
+        "type": "address"
+      }
+    ],
+    "name": "TradingAuthorityWhitelisted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "ORDER_TYPEHASH",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "trader",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "assertTradingAuthority",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "bibliophile",
+    "outputs": [
+      {
+        "internalType": "contract IHubbleBibliophile",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -358,9 +673,14 @@ var OrderBookAbi = []byte(`{"abi": [
             "internalType": "bool",
             "name": "reduceOnly",
             "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "postOnly",
+            "type": "bool"
           }
         ],
-        "internalType": "struct ILimitOrderBook.Order[]",
+        "internalType": "struct ILimitOrderBook.OrderV2[]",
         "name": "orders",
         "type": "tuple[]"
       }
@@ -373,8 +693,71 @@ var OrderBookAbi = []byte(`{"abi": [
   {
     "inputs": [
       {
-        "internalType": "bytes[2]",
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "ammIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "trader",
+            "type": "address"
+          },
+          {
+            "internalType": "int256",
+            "name": "baseAssetQuantity",
+            "type": "int256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "reduceOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "postOnly",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct ILimitOrderBook.OrderV2[]",
         "name": "orders",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "cancelOrdersWithLowMargin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "clearingHouse",
+    "outputs": [
+      {
+        "internalType": "contract IClearingHouse",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes[2]",
+        "name": "data",
         "type": "bytes[2]"
       },
       {
@@ -442,6 +825,127 @@ var OrderBookAbi = []byte(`{"abi": [
   {
     "inputs": [
       {
+        "components": [
+          {
+            "internalType": "uint256",
+            "name": "ammIndex",
+            "type": "uint256"
+          },
+          {
+            "internalType": "address",
+            "name": "trader",
+            "type": "address"
+          },
+          {
+            "internalType": "int256",
+            "name": "baseAssetQuantity",
+            "type": "int256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "price",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "salt",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bool",
+            "name": "reduceOnly",
+            "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "postOnly",
+            "type": "bool"
+          }
+        ],
+        "internalType": "struct ILimitOrderBook.OrderV2",
+        "name": "order",
+        "type": "tuple"
+      }
+    ],
+    "name": "getOrderHashV2",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "baseAssetQuantity",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "price",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "upperBound",
+        "type": "uint256"
+      }
+    ],
+    "name": "getRequiredMargin",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "requiredMargin",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "governance",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_version",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_governance",
+        "type": "address"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "int256",
         "name": "minSize",
         "type": "int256"
@@ -456,12 +960,12 @@ var OrderBookAbi = []byte(`{"abi": [
     "inputs": [
       {
         "internalType": "address",
-        "name": "signer",
+        "name": "",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "trader",
+        "name": "",
         "type": "address"
       }
     ],
@@ -480,7 +984,7 @@ var OrderBookAbi = []byte(`{"abi": [
     "inputs": [
       {
         "internalType": "address",
-        "name": "validator",
+        "name": "",
         "type": "address"
       }
     ],
@@ -496,6 +1000,19 @@ var OrderBookAbi = []byte(`{"abi": [
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "juror",
+    "outputs": [
+      {
+        "internalType": "contract IJuror",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "address",
@@ -504,18 +1021,140 @@ var OrderBookAbi = []byte(`{"abi": [
       },
       {
         "internalType": "bytes",
-        "name": "order",
+        "name": "data",
         "type": "bytes"
       },
       {
         "internalType": "uint256",
-        "name": "toLiquidate",
+        "name": "liquidationAmount",
         "type": "uint256"
       }
     ],
     "name": "liquidateAndExecuteOrder",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "longOpenOrdersAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "marginAccount",
+    "outputs": [
+      {
+        "internalType": "contract IMarginAccount",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "minAllowableMargin",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "minSizes",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "name": "orderHandlers",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "name": "orderInfo",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockPlaced",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "filledAmount",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reservedMargin",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum IOrderHandler.OrderStatus",
+        "name": "status",
+        "type": "uint8"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -562,46 +1201,45 @@ var OrderBookAbi = []byte(`{"abi": [
   {
     "inputs": [
       {
-        "components": [
-          {
-            "internalType": "uint256",
-            "name": "ammIndex",
-            "type": "uint256"
-          },
-          {
-            "internalType": "address",
-            "name": "trader",
-            "type": "address"
-          },
-          {
-            "internalType": "int256",
-            "name": "baseAssetQuantity",
-            "type": "int256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "price",
-            "type": "uint256"
-          },
-          {
-            "internalType": "uint256",
-            "name": "salt",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bool",
-            "name": "reduceOnly",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct ILimitOrderBook.Order",
-        "name": "order",
-        "type": "tuple"
+        "internalType": "string",
+        "name": "err",
+        "type": "string"
       }
     ],
-    "name": "placeOrder",
+    "name": "parseMatchingError",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "orderHash",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "string",
+        "name": "reason",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pause",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -637,14 +1275,139 @@ var OrderBookAbi = []byte(`{"abi": [
             "internalType": "bool",
             "name": "reduceOnly",
             "type": "bool"
+          },
+          {
+            "internalType": "bool",
+            "name": "postOnly",
+            "type": "bool"
           }
         ],
-        "internalType": "struct ILimitOrderBook.Order[]",
+        "internalType": "struct ILimitOrderBook.OrderV2[]",
         "name": "orders",
         "type": "tuple[]"
       }
     ],
     "name": "placeOrders",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "reduceOnlyAmount",
+    "outputs": [
+      {
+        "internalType": "int256",
+        "name": "",
+        "type": "int256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "referral",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "authority",
+        "type": "address"
+      }
+    ],
+    "name": "revokeTradingAuthority",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_bibliophile",
+        "type": "address"
+      }
+    ],
+    "name": "setBibliophile",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "__governance",
+        "type": "address"
+      }
+    ],
+    "name": "setGovernace",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_juror",
+        "type": "address"
+      }
+    ],
+    "name": "setJuror",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint8",
+        "name": "orderType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "address",
+        "name": "handler",
+        "type": "address"
+      }
+    ],
+    "name": "setOrderHandler",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_referral",
+        "type": "address"
+      }
+    ],
+    "name": "setReferral",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -668,6 +1431,24 @@ var OrderBookAbi = []byte(`{"abi": [
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "status",
+        "type": "bool"
+      }
+    ],
+    "name": "setValidatorStatus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
     "name": "settleFunding",
     "outputs": [],
@@ -677,8 +1458,70 @@ var OrderBookAbi = []byte(`{"abi": [
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "shortOpenOrdersAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "takerFee",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "ammIndex",
+        "type": "uint256"
+      },
+      {
+        "internalType": "int256",
+        "name": "minSize",
+        "type": "int256"
+      }
+    ],
+    "name": "updateMinSize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes",
-        "name": "data",
+        "name": "encodedOrder",
         "type": "bytes"
       },
       {
@@ -696,12 +1539,12 @@ var OrderBookAbi = []byte(`{"abi": [
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "minAllowableMargin",
+        "name": "_minAllowableMargin",
         "type": "uint256"
       },
       {
         "internalType": "uint256",
-        "name": "takerFee",
+        "name": "_takerFee",
         "type": "uint256"
       }
     ],
@@ -709,5 +1552,32 @@ var OrderBookAbi = []byte(`{"abi": [
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "useNewPricingAlgorithm",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "authority",
+        "type": "address"
+      }
+    ],
+    "name": "whitelistTradingAuthority",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
   }
-]}`)
+]
+}`)

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -226,6 +226,96 @@ func (cep *ContractEventsProcessor) handleOrderBookEvent(event *types.Log) {
 				return
 			}
 		}
+
+	// event OrderAccepted(address indexed trader, bytes32 indexed orderHash, OrderV2 order, uint timestamp);
+	case cep.orderBookABI.Events["OrderAccepted"].ID:
+		err := cep.orderBookABI.UnpackIntoMap(args, "OrderAccepted", event.Data)
+		if err != nil {
+			log.Error("error in orderBookAbi.UnpackIntoMap", "method", "OrderAccepted", "err", err)
+			return
+		}
+
+		orderId := event.Topics[2]
+		if !removed {
+			timestamp := args["timestamp"].(*big.Int)
+			order := LimitOrderV2{}
+			order.DecodeFromRawOrder(args["order"])
+
+			limitOrder := Order{
+				Id:                      orderId,
+				Market:                  Market(order.AmmIndex.Int64()),
+				PositionType:            getPositionTypeBasedOnBaseAssetQuantity(order.BaseAssetQuantity),
+				UserAddress:             getAddressFromTopicHash(event.Topics[1]).String(),
+				BaseAssetQuantity:       order.BaseAssetQuantity,
+				FilledBaseAssetQuantity: big.NewInt(0),
+				Price:                   order.Price,
+				RawOrder:                &order,
+				Salt:                    order.Salt,
+				ReduceOnly:              order.ReduceOnly,
+				BlockNumber:             big.NewInt(int64(event.BlockNumber)),
+				OrderType:               LimitOrderType,
+			}
+			log.Info("LimitOrder/OrderAccepted", "order", limitOrder, "number", event.BlockNumber, "timestamp", timestamp)
+			cep.database.Add(&limitOrder)
+		} else {
+			log.Info("LimitOrder/OrderAccepted removed", "args", args, "orderId", orderId.String(), "number", event.BlockNumber)
+			cep.database.Delete(orderId)
+		}
+
+	// event OrderRejected(address indexed trader, bytes32 indexed orderHash, OrderV2 order, uint timestamp, string err);
+	case cep.orderBookABI.Events["OrderRejected"].ID:
+		err := cep.orderBookABI.UnpackIntoMap(args, "OrderRejected", event.Data)
+		if err != nil {
+			log.Error("error in orderBookAbi.UnpackIntoMap", "method", "OrderRejected", "err", err)
+			return
+		}
+
+		orderId := event.Topics[2]
+		order := args["order"]
+		if !removed {
+			log.Info("LimitOrder/OrderRejected", "args", args, "orderId", orderId.String(), "number", event.BlockNumber, "order", order)
+		} else {
+			log.Info("LimitOrder/OrderRejected removed", "args", args, "orderId", orderId.String(), "number", event.BlockNumber, "order", order)
+		}
+
+	// event OrderCancelAccepted(address indexed trader, bytes32 indexed orderHash, uint timestamp);
+	case cep.orderBookABI.Events["OrderCancelAccepted"].ID:
+		err := cep.orderBookABI.UnpackIntoMap(args, "OrderCancelAccepted", event.Data)
+		if err != nil {
+			log.Error("error in orderBookAbi.UnpackIntoMap", "method", "OrderCancelAccepted", "err", err)
+			return
+		}
+
+		orderId := event.Topics[2]
+		if !removed {
+			timestamp := args["timestamp"].(*big.Int)
+			log.Info("LimitOrder/OrderCancelAccepted", "args", args, "orderId", orderId.String(), "number", event.BlockNumber, "timestamp", timestamp)
+			if err := cep.database.SetOrderStatus(orderId, Cancelled, "", event.BlockNumber); err != nil {
+				log.Error("error in SetOrderStatus", "method", "OrderCancelAccepted", "err", err)
+				return
+			}
+		} else {
+			log.Info("LimitOrder/OrderCancelAccepted removed", "args", args, "orderId", orderId.String(), "number", event.BlockNumber)
+			if err := cep.database.RevertLastStatus(orderId); err != nil {
+				log.Error("error in SetOrderStatus", "method", "OrderCancelAccepted", "removed", true, "err", err)
+				return
+			}
+		}
+
+	// event OrderCancelRejected(address indexed trader, bytes32 indexed orderHash, uint timestamp, string err);
+	case cep.orderBookABI.Events["OrderCancelRejected"].ID:
+		err := cep.orderBookABI.UnpackIntoMap(args, "OrderCancelRejected", event.Data)
+		if err != nil {
+			log.Error("error in orderBookAbi.UnpackIntoMap", "method", "OrderCancelRejected", "err", err)
+			return
+		}
+
+		orderId := event.Topics[2]
+		if !removed {
+			log.Info("LimitOrder/OrderCancelRejected", "args", args, "orderId", orderId.String(), "number", event.BlockNumber)
+		} else {
+			log.Info("LimitOrder/OrderCancelRejected removed", "args", args, "orderId", orderId.String(), "number", event.BlockNumber)
+		}
 	}
 }
 
@@ -384,6 +474,16 @@ func (cep *ContractEventsProcessor) handleClearingHouseEvent(event *types.Log) {
 		size := args["size"].(*big.Int)
 		log.Info("PositionLiquidated", "market", market, "trader", trader, "args", args)
 		cep.database.UpdatePosition(trader, market, size, openNotional, true)
+
+	// event SamplePI(uint nextSampleTime);
+	case cep.clearingHouseABI.Events["SamplePI"].ID:
+		err := cep.clearingHouseABI.UnpackIntoMap(args, "SamplePI", event.Data)
+		if err != nil {
+			log.Error("error in clearingHouseABI.UnpackIntoMap", "method", "SamplePI", "err", err)
+			return
+		}
+		nextSampleTime := args["nextSampleTime"].(*big.Int)
+		cep.database.UpdateNextSamplePITime(nextSampleTime.Uint64())
 	}
 }
 

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -546,6 +546,32 @@ func (cep *ContractEventsProcessor) PushtoTraderFeed(events []*types.Log, blockS
 				orderId = event.Topics[2]
 				trader = getAddressFromTopicHash(event.Topics[1])
 
+			case cep.orderBookABI.Events["OrderAccepted"].ID:
+				err := cep.orderBookABI.UnpackIntoMap(args, "OrderAccepted", event.Data)
+				if err != nil {
+					log.Error("error in orderBookABI.UnpackIntoMap", "method", "OrderAccepted", "err", err)
+					continue
+				}
+				eventName = "OrderAccepted"
+				order := LimitOrderV2{}
+				order.DecodeFromRawOrder(args["order"])
+				args["order"] = order.Map()
+				orderId = event.Topics[2]
+				trader = getAddressFromTopicHash(event.Topics[1])
+
+			case cep.orderBookABI.Events["OrderRejected"].ID:
+				err := cep.orderBookABI.UnpackIntoMap(args, "OrderRejected", event.Data)
+				if err != nil {
+					log.Error("error in orderBookABI.UnpackIntoMap", "method", "OrderRejected", "err", err)
+					continue
+				}
+				eventName = "OrderRejected"
+				order := LimitOrderV2{}
+				order.DecodeFromRawOrder(args["order"])
+				args["order"] = order.Map()
+				orderId = event.Topics[2]
+				trader = getAddressFromTopicHash(event.Topics[1])
+
 			case cep.orderBookABI.Events["OrderMatched"].ID:
 				err := cep.orderBookABI.UnpackIntoMap(args, "OrderMatched", event.Data)
 				if err != nil {
@@ -569,6 +595,26 @@ func (cep *ContractEventsProcessor) PushtoTraderFeed(events []*types.Log, blockS
 					continue
 				}
 				eventName = "OrderCancelled"
+				orderId = event.Topics[2]
+				trader = getAddressFromTopicHash(event.Topics[1])
+
+			case cep.orderBookABI.Events["OrderCancelAccepted"].ID:
+				err := cep.orderBookABI.UnpackIntoMap(args, "OrderCancelAccepted", event.Data)
+				if err != nil {
+					log.Error("error in orderBookABI.UnpackIntoMap", "method", "OrderCancelAccepted", "err", err)
+					continue
+				}
+				eventName = "OrderCancelAccepted"
+				orderId = event.Topics[2]
+				trader = getAddressFromTopicHash(event.Topics[1])
+
+			case cep.orderBookABI.Events["OrderCancelRejected"].ID:
+				err := cep.orderBookABI.UnpackIntoMap(args, "OrderCancelRejected", event.Data)
+				if err != nil {
+					log.Error("error in orderBookABI.UnpackIntoMap", "method", "OrderCancelRejected", "err", err)
+					continue
+				}
+				eventName = "OrderCancelRejected"
 				orderId = event.Topics[2]
 				trader = getAddressFromTopicHash(event.Topics[1])
 

--- a/plugin/evm/orderbook/contract_events_processor_test.go
+++ b/plugin/evm/orderbook/contract_events_processor_test.go
@@ -324,13 +324,14 @@ func TestHandleOrderBookEvent(t *testing.T) {
 		}
 		limitOrder.Id = getIdFromOrder(*limitOrder)
 		db.Add(limitOrder)
-		// t.Run("When data in log unpack fails", func(t *testing.T) {
-		// 	orderCancelledEventData := []byte{}
-		// 	log := getEventLog(OrderBookContractAddress, topics, orderCancelledEventData, blockNumber)
-		// 	cep.ProcessEvents([]*types.Log{log})
-		// 	actualLimitOrder := db.GetOrderBookData().OrderMap[orderId]
-		// 	assert.Equal(t, limitOrder, actualLimitOrder)
-		// })
+		t.Run("When data in log unpack fails", func(t *testing.T) {
+			orderCancelledEventData := []byte{}
+			log := getEventLog(OrderBookContractAddress, topics, orderCancelledEventData, blockNumber)
+			cep.ProcessEvents([]*types.Log{log})
+			orderId := getIdFromOrder(*limitOrder)
+			actualLimitOrder := db.GetOrderBookData().OrderMap[orderId]
+			assert.Equal(t, limitOrder, actualLimitOrder)
+		})
 		t.Run("When data in log unpack succeeds", func(t *testing.T) {
 			orderCancelledEventData, _ := event.Inputs.NonIndexed().Pack(timestamp)
 			log := getEventLog(OrderBookContractAddress, topics, orderCancelledEventData, blockNumber)

--- a/plugin/evm/orderbook/contract_events_processor_test.go
+++ b/plugin/evm/orderbook/contract_events_processor_test.go
@@ -29,12 +29,12 @@ func TestProcessEvents(t *testing.T) {
 		baseAssetQuantity := big.NewInt(5000000000000000000)
 		price := big.NewInt(1000000000)
 		salt1 := big.NewInt(1675239557437)
-		longOrder := getOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt1)
-		longOrderId := getIdFromOrder(longOrder)
+		longOrder := getLimitOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt1)
+		longOrderId := getIdFromLimitOrder(longOrder)
 
 		salt2 := big.NewInt(0).Add(salt1, big.NewInt(1))
-		shortOrder := getOrder(ammIndex, traderAddress, big.NewInt(0).Neg(baseAssetQuantity), price, salt2)
-		shortOrderId := getIdFromOrder(shortOrder)
+		shortOrder := getLimitOrder(ammIndex, traderAddress, big.NewInt(0).Neg(baseAssetQuantity), price, salt2)
+		shortOrderId := getIdFromLimitOrder(shortOrder)
 
 		ordersPlacedBlockNumber := uint64(12)
 		orderPlacedEvent := getEventFromABI(limitOrderBookABI, "OrderPlaced")
@@ -64,10 +64,10 @@ func TestProcessEvents(t *testing.T) {
 		// changed from the following which waws meaning to test the sorted-ness of the events before processing
 		// cep.ProcessEvents([]*types.Log{ordersMatchedEventLog, longOrderPlacedEventLog, shortOrderPlacedEventLog})
 
-		actualLongOrder := db.OrderMap[getIdFromOrder(longOrder)]
+		actualLongOrder := db.OrderMap[getIdFromLimitOrder(longOrder)]
 		assert.Equal(t, fillAmount, actualLongOrder.FilledBaseAssetQuantity)
 
-		actualShortOrder := db.OrderMap[getIdFromOrder(shortOrder)]
+		actualShortOrder := db.OrderMap[getIdFromLimitOrder(shortOrder)]
 		assert.Equal(t, big.NewInt(0).Neg(fillAmount), actualShortOrder.FilledBaseAssetQuantity)
 	})
 
@@ -129,12 +129,12 @@ func TestOrderBookMarginAccountClearingHouseEventInLog(t *testing.T) {
 	baseAssetQuantity := big.NewInt(5000000000000000000)
 	price := big.NewInt(1000000000)
 	salt := big.NewInt(1675239557437)
-	order := getOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt)
+	order := getLimitOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt)
 	orderBookABI := getABIfromJson(abis.OrderBookAbi)
 	limitOrderBookABI := getABIfromJson(abis.OrderBookAbi)
 	orderBookEvent := getEventFromABI(limitOrderBookABI, "OrderPlaced")
 	orderPlacedEventData, _ := orderBookEvent.Inputs.NonIndexed().Pack(order, timestamp)
-	orderBookEventTopics := []common.Hash{orderBookEvent.ID, traderAddress.Hash(), getIdFromOrder(order)}
+	orderBookEventTopics := []common.Hash{orderBookEvent.ID, traderAddress.Hash(), getIdFromLimitOrder(order)}
 	orderBookLog := getEventLog(OrderBookContractAddress, orderBookEventTopics, orderPlacedEventData, blockNumber)
 
 	//MarginAccount Contract log
@@ -162,7 +162,7 @@ func TestOrderBookMarginAccountClearingHouseEventInLog(t *testing.T) {
 	cep.ProcessAcceptedEvents([]*types.Log{marginAccountLog, clearingHouseLog}, true)
 
 	//OrderBook log - OrderPlaced
-	actualLimitOrder := *db.GetOrderBookData().OrderMap[getIdFromOrder(order)]
+	actualLimitOrder := *db.GetOrderBookData().OrderMap[getIdFromLimitOrder(order)]
 	args := map[string]interface{}{}
 	orderBookABI.UnpackIntoMap(args, "OrderPlaced", orderPlacedEventData)
 	assert.Equal(t, Market(ammIndex.Int64()), actualLimitOrder.Market)
@@ -192,7 +192,7 @@ func TestHandleOrderBookEvent(t *testing.T) {
 	baseAssetQuantity := big.NewInt(5000000000000000000)
 	price := big.NewInt(1000000000)
 	salt := big.NewInt(1675239557437)
-	order := getOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt)
+	order := getLimitOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt)
 	blockNumber := uint64(12)
 	orderBookABI := getABIfromJson(abis.OrderBookAbi)
 
@@ -200,12 +200,12 @@ func TestHandleOrderBookEvent(t *testing.T) {
 		db := getDatabase()
 		cep := newcep(t, db)
 		event := getEventFromABI(orderBookABI, "OrderPlaced")
-		topics := []common.Hash{event.ID, traderAddress.Hash(), getIdFromOrder(order)}
+		topics := []common.Hash{event.ID, traderAddress.Hash(), getIdFromLimitOrder(order)}
 		t.Run("When data in log unpack fails", func(t *testing.T) {
 			orderPlacedEventData := []byte{}
 			log := getEventLog(OrderBookContractAddress, topics, orderPlacedEventData, blockNumber)
 			cep.ProcessEvents([]*types.Log{log})
-			actualLimitOrder := db.GetOrderBookData().OrderMap[getIdFromOrder(order)]
+			actualLimitOrder := db.GetOrderBookData().OrderMap[getIdFromLimitOrder(order)]
 			assert.Nil(t, actualLimitOrder)
 		})
 		t.Run("When data in log unpack succeeds", func(t *testing.T) {
@@ -232,11 +232,51 @@ func TestHandleOrderBookEvent(t *testing.T) {
 			assert.Equal(t, rawOrder, actualLimitOrder.RawOrder.(*LimitOrder))
 		})
 	})
+
+	t.Run("When event is OrderAccepted", func(t *testing.T) {
+		db := getDatabase()
+		cep := newcep(t, db)
+		event := getEventFromABI(orderBookABI, "OrderAccepted")
+		orderV2 := getLimitOrderV2(ammIndex, traderAddress, baseAssetQuantity, price, salt)
+		orderId := getIdFromLimitOrderV2(orderV2)
+		topics := []common.Hash{event.ID, traderAddress.Hash(), orderId}
+		t.Run("When data in log unpack fails", func(t *testing.T) {
+			orderAcceptedEventData := []byte{}
+			log := getEventLog(OrderBookContractAddress, topics, orderAcceptedEventData, blockNumber)
+			cep.ProcessEvents([]*types.Log{log})
+			actualLimitOrder := db.GetOrderBookData().OrderMap[orderId]
+			assert.Nil(t, actualLimitOrder)
+		})
+		t.Run("When data in log unpack succeeds", func(t *testing.T) {
+			orderAcceptedEventData, err := event.Inputs.NonIndexed().Pack(orderV2, timestamp)
+			if err != nil {
+				t.Fatalf("%s", err)
+			}
+			log := getEventLog(OrderBookContractAddress, topics, orderAcceptedEventData, blockNumber)
+			cep.ProcessEvents([]*types.Log{log})
+
+			actualLimitOrder := db.GetOrderBookData().OrderMap[orderId]
+			args := map[string]interface{}{}
+			orderBookABI.UnpackIntoMap(args, "OrderAccepted", orderAcceptedEventData)
+			assert.Equal(t, Market(ammIndex.Int64()), actualLimitOrder.Market)
+			assert.Equal(t, LONG, actualLimitOrder.PositionType)
+			assert.Equal(t, traderAddress.String(), actualLimitOrder.UserAddress)
+			assert.Equal(t, *baseAssetQuantity, *actualLimitOrder.BaseAssetQuantity)
+			assert.Equal(t, false, actualLimitOrder.ReduceOnly)
+			assert.Equal(t, false, actualLimitOrder.isPostOnly())
+			assert.Equal(t, *price, *actualLimitOrder.Price)
+			assert.Equal(t, Placed, actualLimitOrder.getOrderStatus().Status)
+			assert.Equal(t, big.NewInt(int64(blockNumber)), actualLimitOrder.BlockNumber)
+			rawOrder := &LimitOrderV2{}
+			rawOrder.DecodeFromRawOrder(args["order"])
+			assert.Equal(t, rawOrder, actualLimitOrder.RawOrder.(*LimitOrderV2))
+		})
+	})
 	t.Run("When event is OrderCancelled", func(t *testing.T) {
 		db := getDatabase()
 		cep := newcep(t, db)
 		event := getEventFromABI(orderBookABI, "OrderCancelled")
-		topics := []common.Hash{event.ID, traderAddress.Hash(), getIdFromOrder(order)}
+		topics := []common.Hash{event.ID, traderAddress.Hash(), getIdFromLimitOrder(order)}
 		blockNumber := uint64(4)
 		limitOrder := &Order{
 			Market:            Market(ammIndex.Int64()),
@@ -247,7 +287,7 @@ func TestHandleOrderBookEvent(t *testing.T) {
 			BlockNumber:       big.NewInt(1),
 			Salt:              salt,
 		}
-		limitOrder.Id = getIdFromLimitOrder(*limitOrder)
+		limitOrder.Id = getIdFromOrder(*limitOrder)
 		db.Add(limitOrder)
 		// t.Run("When data in log unpack fails", func(t *testing.T) {
 		// 	orderCancelledEventData := []byte{}
@@ -259,7 +299,42 @@ func TestHandleOrderBookEvent(t *testing.T) {
 		t.Run("When data in log unpack succeeds", func(t *testing.T) {
 			orderCancelledEventData, _ := event.Inputs.NonIndexed().Pack(timestamp)
 			log := getEventLog(OrderBookContractAddress, topics, orderCancelledEventData, blockNumber)
-			orderId := getIdFromLimitOrder(*limitOrder)
+			orderId := getIdFromOrder(*limitOrder)
+			cep.ProcessEvents([]*types.Log{log})
+			actualLimitOrder := db.GetOrderBookData().OrderMap[orderId]
+			assert.Equal(t, Cancelled, actualLimitOrder.getOrderStatus().Status)
+		})
+	})
+	t.Run("When event is OrderCancelAccepted", func(t *testing.T) {
+		db := getDatabase()
+		cep := newcep(t, db)
+		orderV2 := getLimitOrderV2(ammIndex, traderAddress, baseAssetQuantity, price, salt)
+		event := getEventFromABI(orderBookABI, "OrderCancelAccepted")
+		topics := []common.Hash{event.ID, traderAddress.Hash(), getIdFromLimitOrderV2(orderV2)}
+		blockNumber := uint64(4)
+		limitOrder := &Order{
+			Market:            Market(ammIndex.Int64()),
+			PositionType:      LONG,
+			UserAddress:       traderAddress.String(),
+			BaseAssetQuantity: baseAssetQuantity,
+			Price:             price,
+			BlockNumber:       big.NewInt(1),
+			Salt:              salt,
+			RawOrder:          &orderV2,
+		}
+		limitOrder.Id = getIdFromOrder(*limitOrder)
+		db.Add(limitOrder)
+		// t.Run("When data in log unpack fails", func(t *testing.T) {
+		// 	orderCancelledEventData := []byte{}
+		// 	log := getEventLog(OrderBookContractAddress, topics, orderCancelledEventData, blockNumber)
+		// 	cep.ProcessEvents([]*types.Log{log})
+		// 	actualLimitOrder := db.GetOrderBookData().OrderMap[orderId]
+		// 	assert.Equal(t, limitOrder, actualLimitOrder)
+		// })
+		t.Run("When data in log unpack succeeds", func(t *testing.T) {
+			orderCancelledEventData, _ := event.Inputs.NonIndexed().Pack(timestamp)
+			log := getEventLog(OrderBookContractAddress, topics, orderCancelledEventData, blockNumber)
+			orderId := getIdFromOrder(*limitOrder)
 			cep.ProcessEvents([]*types.Log{log})
 			actualLimitOrder := db.GetOrderBookData().OrderMap[orderId]
 			assert.Equal(t, Cancelled, actualLimitOrder.getOrderStatus().Status)
@@ -290,8 +365,8 @@ func TestHandleOrderBookEvent(t *testing.T) {
 			Salt:                    big.NewInt(0).Add(salt, big.NewInt(1000)),
 		}
 
-		longOrder.Id = getIdFromLimitOrder(*longOrder)
-		shortOrder.Id = getIdFromLimitOrder(*shortOrder)
+		longOrder.Id = getIdFromOrder(*longOrder)
+		shortOrder.Id = getIdFromOrder(*shortOrder)
 		db.Add(longOrder)
 		db.Add(shortOrder)
 		relayer := common.HexToAddress("0x710bf5F942331874dcBC7783319123679033b63b")
@@ -326,7 +401,7 @@ func TestHandleOrderBookEvent(t *testing.T) {
 			BlockNumber:             big.NewInt(1),
 			FilledBaseAssetQuantity: big.NewInt(0),
 		}
-		longOrder.Id = getIdFromLimitOrder(*longOrder)
+		longOrder.Id = getIdFromOrder(*longOrder)
 		db.Add(longOrder)
 		relayer := common.HexToAddress("0x710bf5F942331874dcBC7783319123679033b63b")
 		fillAmount := big.NewInt(10)
@@ -653,13 +728,13 @@ func TestRemovedEvents(t *testing.T) {
 	cep := newcep(t, db)
 
 	orderPlacedEvent := getEventFromABI(limitOrderrderBookABI, "OrderPlaced")
-	longOrder := getOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt1)
-	longOrderId := getIdFromOrder(longOrder)
+	longOrder := getLimitOrder(ammIndex, traderAddress, baseAssetQuantity, price, salt1)
+	longOrderId := getIdFromLimitOrder(longOrder)
 	longOrderPlacedEventTopics := []common.Hash{orderPlacedEvent.ID, traderAddress.Hash(), longOrderId}
 	longOrderPlacedEventData, _ := orderPlacedEvent.Inputs.NonIndexed().Pack(longOrder, timestamp)
 
-	shortOrder := getOrder(ammIndex, traderAddress2, big.NewInt(0).Neg(baseAssetQuantity), price, salt2)
-	shortOrderId := getIdFromOrder(shortOrder)
+	shortOrder := getLimitOrder(ammIndex, traderAddress2, big.NewInt(0).Neg(baseAssetQuantity), price, salt2)
+	shortOrderId := getIdFromLimitOrder(shortOrder)
 	shortOrderPlacedEventTopics := []common.Hash{orderPlacedEvent.ID, traderAddress2.Hash(), shortOrderId}
 	shortOrderPlacedEventData, _ := orderPlacedEvent.Inputs.NonIndexed().Pack(shortOrder, timestamp)
 
@@ -728,7 +803,7 @@ func TestRemovedEvents(t *testing.T) {
 	t.Run("un-fulfill an order when LiquidationOrderMatched is removed", func(t *testing.T) {
 		// change salt to create a new order in memory
 		longOrder.Salt.Add(longOrder.Salt, big.NewInt(10))
-		longOrderId = getIdFromOrder(longOrder)
+		longOrderId = getIdFromLimitOrder(longOrder)
 		longOrderPlacedEventTopics = []common.Hash{orderPlacedEvent.ID, traderAddress.Hash(), longOrderId}
 		longOrderPlacedEventData, _ = orderPlacedEvent.Inputs.NonIndexed().Pack(longOrder, timestamp)
 		longOrderPlacedEventLog := getEventLog(OrderBookContractAddress, longOrderPlacedEventTopics, longOrderPlacedEventData, blockNumber.Uint64())
@@ -756,7 +831,7 @@ func TestRemovedEvents(t *testing.T) {
 	t.Run("revert state of an order when OrderMatchingError is removed", func(t *testing.T) {
 		// change salt
 		longOrder.Salt.Add(longOrder.Salt, big.NewInt(20))
-		longOrderId = getIdFromOrder(longOrder)
+		longOrderId = getIdFromLimitOrder(longOrder)
 		longOrderPlacedEventTopics = []common.Hash{orderPlacedEvent.ID, traderAddress.Hash(), longOrderId}
 		longOrderPlacedEventData, _ = orderPlacedEvent.Inputs.NonIndexed().Pack(longOrder, timestamp)
 		longOrderPlacedEventLog := getEventLog(OrderBookContractAddress, longOrderPlacedEventTopics, longOrderPlacedEventData, blockNumber.Uint64())
@@ -803,7 +878,7 @@ func getEventFromABI(contractABI abi.ABI, eventName string) abi.Event {
 	return abi.Event{}
 }
 
-func getOrder(ammIndex *big.Int, traderAddress common.Address, baseAssetQuantity *big.Int, price *big.Int, salt *big.Int) LimitOrder {
+func getLimitOrder(ammIndex *big.Int, traderAddress common.Address, baseAssetQuantity *big.Int, price *big.Int, salt *big.Int) LimitOrder {
 	return LimitOrder{
 		AmmIndex:          ammIndex,
 		Trader:            traderAddress,
@@ -811,6 +886,20 @@ func getOrder(ammIndex *big.Int, traderAddress common.Address, baseAssetQuantity
 		Price:             price,
 		Salt:              salt,
 		ReduceOnly:        false,
+	}
+}
+
+func getLimitOrderV2(ammIndex *big.Int, traderAddress common.Address, baseAssetQuantity *big.Int, price *big.Int, salt *big.Int) LimitOrderV2 {
+	return LimitOrderV2{
+		LimitOrder: LimitOrder{
+			AmmIndex:          ammIndex,
+			Trader:            traderAddress,
+			BaseAssetQuantity: baseAssetQuantity,
+			Price:             price,
+			Salt:              salt,
+			ReduceOnly:        false,
+		},
+		PostOnly: false,
 	}
 }
 
@@ -824,11 +913,16 @@ func getEventLog(contractAddress common.Address, topics []common.Hash, eventData
 }
 
 // @todo change this to return the EIP712 hash instead
-func getIdFromOrder(order LimitOrder) common.Hash {
+func getIdFromLimitOrder(order LimitOrder) common.Hash {
 	return crypto.Keccak256Hash([]byte(order.Trader.String() + order.Salt.String()))
 }
 
 // @todo change this to return the EIP712 hash instead
-func getIdFromLimitOrder(order Order) common.Hash {
+func getIdFromOrder(order Order) common.Hash {
 	return crypto.Keccak256Hash([]byte(order.UserAddress + order.Salt.String()))
+}
+
+// @todo change this to return the EIP712 hash instead
+func getIdFromLimitOrderV2(order LimitOrderV2) common.Hash {
+	return crypto.Keccak256Hash([]byte(order.Trader.String() + order.Salt.String()))
 }

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -261,9 +261,11 @@ func matchLongAndShortOrder(lotp LimitOrderTxProcessor, longOrder, shortOrder Or
 	}
 	if longOrder.BlockNumber.Cmp(shortOrder.BlockNumber) > 0 && longOrder.isPostOnly() {
 		log.Warn("post only long order matched with a resting order", "longOrder", longOrder, "shortOrder", shortOrder)
+		return longOrder, shortOrder, false
 	}
 	if shortOrder.BlockNumber.Cmp(longOrder.BlockNumber) > 0 && shortOrder.isPostOnly() {
 		log.Warn("post only short order matched with a resting order", "longOrder", longOrder, "shortOrder", shortOrder)
+		return longOrder, shortOrder, false
 	}
 	if err := lotp.ExecuteMatchedOrdersTx(longOrder, shortOrder, fillAmount); err != nil {
 		return longOrder, shortOrder, false

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -60,6 +60,15 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 		}
 	}
 
+	// check nextSamplePITime
+	if isSamplePITime(pipeline.db.GetNextSamplePITime()) {
+		log.Info("MatchingPipeline:isSamplePITime")
+		err := pipeline.lotp.ExecuteSamplePITx()
+		if err != nil {
+			log.Error("Sample PI job failed", "err", err)
+		}
+	}
+
 	// fetch the underlying price and run the matching engine
 	underlyingPrices := pipeline.GetUnderlyingPrices()
 
@@ -77,11 +86,7 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	}
 
 	orderBookTxsCount := pipeline.lotp.GetOrderBookTxsCount()
-	if orderBookTxsCount > 0 {
-		return true
-	}
-
-	return false
+	return orderBookTxsCount > 0
 }
 
 type Orders struct {
@@ -113,9 +118,9 @@ func (pipeline *MatchingPipeline) cancelLimitOrders(cancellableOrders map[common
 	// @todo: if there are too many cancellable orders, they might not fit in a single block. Need to adjust for that.
 	for _, orders := range cancellableOrders {
 		if len(orders) > 0 {
-			rawOrders := make([]LimitOrder, len(orders))
+			rawOrders := make([]LimitOrderV2, len(orders))
 			for i, order := range orders {
-				rawOrder := order.RawOrder.(*LimitOrder)
+				rawOrder := order.RawOrder.(*LimitOrderV2)
 				rawOrders[i] = *rawOrder // @todo: make sure only limit orders reach here
 			}
 			log.Info("orders to cancel", "num", len(orders))
@@ -254,6 +259,12 @@ func matchLongAndShortOrder(lotp LimitOrderTxProcessor, longOrder, shortOrder Or
 	if longOrder.Price.Cmp(shortOrder.Price) == -1 || fillAmount.Sign() == 0 {
 		return longOrder, shortOrder, false
 	}
+	if longOrder.BlockNumber.Cmp(shortOrder.BlockNumber) > 0 && longOrder.isPostOnly() {
+		log.Warn("post only long order matched with a resting order", "longOrder", longOrder, "shortOrder", shortOrder)
+	}
+	if shortOrder.BlockNumber.Cmp(longOrder.BlockNumber) > 0 && shortOrder.isPostOnly() {
+		log.Warn("post only short order matched with a resting order", "longOrder", longOrder, "shortOrder", shortOrder)
+	}
 	if err := lotp.ExecuteMatchedOrdersTx(longOrder, shortOrder, fillAmount); err != nil {
 		return longOrder, shortOrder, false
 	}
@@ -269,6 +280,15 @@ func isFundingPaymentTime(nextFundingTime uint64) bool {
 
 	now := uint64(time.Now().Unix())
 	return now >= nextFundingTime
+}
+
+func isSamplePITime(nextSamplePITime uint64) bool {
+	if nextSamplePITime == 0 {
+		return false
+	}
+
+	now := uint64(time.Now().Unix())
+	return now >= nextSamplePITime
 }
 
 func executeFundingPayment(lotp LimitOrderTxProcessor) error {

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -652,8 +652,40 @@ func createLimitOrder(positionType PositionType, userAddress string, baseAssetQu
 		BlockNumber:             blockNumber,
 		ReduceOnly:              false,
 	}
-	lo.Id = getIdFromLimitOrder(lo)
+	lo.Id = getIdFromOrder(lo)
 	return lo
+}
+
+func createIOCOrder(positionType PositionType, userAddress string, baseAssetQuantity *big.Int, price *big.Int, status Status, blockNumber *big.Int, salt *big.Int, expireDuration *big.Int) Order {
+	now := big.NewInt(time.Now().Unix())
+	expireAt := big.NewInt(0).Add(now, expireDuration)
+	ioc := Order{
+		OrderType:               IOCOrderType,
+		Market:                  market,
+		PositionType:            positionType,
+		UserAddress:             userAddress,
+		FilledBaseAssetQuantity: big.NewInt(0),
+		BaseAssetQuantity:       baseAssetQuantity,
+		Price:                   price,
+		Salt:                    salt,
+		BlockNumber:             blockNumber,
+		ReduceOnly:              false,
+		RawOrder: &IOCOrder{
+			OrderType: uint8(IOCOrderType),
+			ExpireAt:  expireAt,
+			LimitOrder: LimitOrder{
+				AmmIndex:          big.NewInt(0),
+				Trader:            common.HexToAddress(userAddress),
+				BaseAssetQuantity: baseAssetQuantity,
+				Price:             price,
+				Salt:              salt,
+				ReduceOnly:        false,
+			},
+		}}
+
+	// it's incorrect but should not affect the test results
+	ioc.Id = getIdFromOrder(ioc)
+	return ioc
 }
 
 func TestGetUnfilledBaseAssetQuantity(t *testing.T) {

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -95,6 +95,12 @@ func (db *MockLimitOrderDatabase) GetLastPrice(market Market) *big.Int {
 	return args.Get(0).(*big.Int)
 }
 
+func (db *MockLimitOrderDatabase) UpdateNextSamplePITime(nextSamplePITime uint64) {}
+
+func (db *MockLimitOrderDatabase) GetNextSamplePITime() uint64 {
+	return 0
+}
+
 func (db *MockLimitOrderDatabase) GetOrdersToCancel(oraclePrice map[Market]*big.Int) map[common.Address][]common.Hash {
 	args := db.Called()
 	return args.Get(0).(map[common.Address][]common.Hash)
@@ -165,12 +171,16 @@ func (lotp *MockLimitOrderTxProcessor) ExecuteFundingPaymentTx() error {
 	return nil
 }
 
+func (lotp *MockLimitOrderTxProcessor) ExecuteSamplePITx() error {
+	return nil
+}
+
 func (lotp *MockLimitOrderTxProcessor) ExecuteLiquidation(trader common.Address, matchedOrder Order, fillAmount *big.Int) error {
 	args := lotp.Called(trader, matchedOrder, fillAmount)
 	return args.Error(0)
 }
 
-func (lotp *MockLimitOrderTxProcessor) ExecuteLimitOrderCancel(orderIds []LimitOrder) error {
+func (lotp *MockLimitOrderTxProcessor) ExecuteLimitOrderCancel(orderIds []LimitOrderV2) error {
 	args := lotp.Called(orderIds)
 	return args.Error(0)
 }

--- a/plugin/evm/orderbook/order_types.go
+++ b/plugin/evm/orderbook/order_types.go
@@ -16,7 +16,7 @@ type ContractOrder interface {
 	Map() map[string]interface{}
 }
 
-// LimitOrder type is copy of LimitOrder struct defined in Orderbook contract
+// LimitOrder type is copy of Order struct defined in LimitOrderbook contract
 type LimitOrder struct {
 	AmmIndex          *big.Int       `json:"ammIndex"`
 	Trader            common.Address `json:"trader"`
@@ -24,6 +24,12 @@ type LimitOrder struct {
 	Price             *big.Int       `json:"price"`
 	Salt              *big.Int       `json:"salt"`
 	ReduceOnly        bool           `json:"reduceOnly"`
+}
+
+// LimitOrderV2 type is copy of OrderV2 struct defined in LimitOrderbook contract
+type LimitOrderV2 struct {
+	LimitOrder
+	PostOnly bool `json:"postOnly"`
 }
 
 // IOCOrder type is copy of IOCOrder struct defined in Orderbook contract
@@ -83,6 +89,59 @@ func DecodeLimitOrder(encodedOrder []byte) (*LimitOrder, error) {
 	limitOrder := &LimitOrder{}
 	limitOrder.DecodeFromRawOrder(order[0])
 	return limitOrder, nil
+}
+
+// LimitOrderV2
+func (order *LimitOrderV2) EncodeToABI() ([]byte, error) {
+	limitOrderV2Type, err := getOrderType("limit_v2")
+	if err != nil {
+		return nil, fmt.Errorf("failed getting abi type: %w", err)
+	}
+	encodedLimitOrderV2, err := abi.Arguments{{Type: limitOrderV2Type}}.Pack(order)
+	if err != nil {
+		return nil, fmt.Errorf("limit order packing failed: %w", err)
+	}
+
+	orderType, _ := abi.NewType("uint8", "uint8", nil)
+	orderBytesType, _ := abi.NewType("bytes", "bytes", nil)
+	// 0 means ordertype = limit order
+	encodedOrder, err := abi.Arguments{{Type: orderType}, {Type: orderBytesType}}.Pack(uint8(0), encodedLimitOrderV2)
+	if err != nil {
+		return nil, fmt.Errorf("order encoding failed: %w", err)
+	}
+
+	return encodedOrder, nil
+}
+
+func (order *LimitOrderV2) DecodeFromRawOrder(rawOrder interface{}) {
+	marshalledOrder, _ := json.Marshal(rawOrder)
+	json.Unmarshal(marshalledOrder, &order)
+}
+
+func (order *LimitOrderV2) Map() map[string]interface{} {
+	return map[string]interface{}{
+		"ammIndex":          order.AmmIndex,
+		"trader":            order.Trader,
+		"baseAssetQuantity": utils.BigIntToFloat(order.BaseAssetQuantity, 18),
+		"price":             utils.BigIntToFloat(order.Price, 6),
+		"reduceOnly":        order.ReduceOnly,
+		"postOnly":          order.PostOnly,
+		"salt":              order.Salt,
+	}
+}
+
+func DecodeLimitOrderV2(encodedOrder []byte) (*LimitOrderV2, error) {
+	limitOrderV2Type, err := getOrderType("limit_v2")
+	if err != nil {
+		return nil, fmt.Errorf("failed getting abi type: %w", err)
+	}
+	order, err := abi.Arguments{{Type: limitOrderV2Type}}.Unpack(encodedOrder)
+	if err != nil {
+		return nil, err
+	}
+	limitOrderV2 := &LimitOrderV2{}
+	limitOrderV2.DecodeFromRawOrder(order[0])
+	return limitOrderV2, nil
 }
 
 // ----------------------------------------------------------------------------
@@ -152,6 +211,17 @@ func getOrderType(orderType string) (abi.Type, error) {
 			{Name: "price", Type: "uint256"},
 			{Name: "salt", Type: "uint256"},
 			{Name: "reduceOnly", Type: "bool"},
+		})
+	}
+	if orderType == "limit_v2" {
+		return abi.NewType("tuple", "", []abi.ArgumentMarshaling{
+			{Name: "ammIndex", Type: "uint256"},
+			{Name: "trader", Type: "address"},
+			{Name: "baseAssetQuantity", Type: "int256"},
+			{Name: "price", Type: "uint256"},
+			{Name: "salt", Type: "uint256"},
+			{Name: "reduceOnly", Type: "bool"},
+			{Name: "postOnly", Type: "bool"},
 		})
 	}
 	if orderType == "ioc" {

--- a/plugin/evm/orderbook/service_test.go
+++ b/plugin/evm/orderbook/service_test.go
@@ -21,18 +21,18 @@ func TestAggregatedOrderBook(t *testing.T) {
 		longOrder2 := getLongOrder()
 		longOrder2.Salt.Add(longOrder2.Salt, big.NewInt(100))
 		longOrder2.Price.Mul(longOrder2.Price, big.NewInt(2))
-		longOrder2.Id = getIdFromLimitOrder(longOrder2)
+		longOrder2.Id = getIdFromOrder(longOrder2)
 		db.Add(&longOrder2)
 
 		shortOrder1 := getShortOrder()
 		shortOrder1.Salt.Add(shortOrder1.Salt, big.NewInt(200))
-		shortOrder1.Id = getIdFromLimitOrder(shortOrder1)
+		shortOrder1.Id = getIdFromOrder(shortOrder1)
 		db.Add(&shortOrder1)
 
 		shortOrder2 := getShortOrder()
 		shortOrder2.Salt.Add(shortOrder1.Salt, big.NewInt(300))
 		shortOrder2.Price.Mul(shortOrder2.Price, big.NewInt(2))
-		shortOrder2.Id = getIdFromLimitOrder(shortOrder2)
+		shortOrder2.Id = getIdFromOrder(shortOrder2)
 		db.Add(&shortOrder2)
 
 		ctx := context.TODO()

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -31,9 +31,10 @@ type LimitOrderTxProcessor interface {
 	PurgeOrderBookTxs()
 	ExecuteMatchedOrdersTx(incomingOrder Order, matchedOrder Order, fillAmount *big.Int) error
 	ExecuteFundingPaymentTx() error
+	ExecuteSamplePITx() error
 	ExecuteLiquidation(trader common.Address, matchedOrder Order, fillAmount *big.Int) error
 	UpdateMetrics(block *types.Block)
-	ExecuteLimitOrderCancel(orderIds []LimitOrder) error
+	ExecuteLimitOrderCancel(orderIds []LimitOrderV2) error
 }
 
 type ValidatorTxFeeConfig struct {
@@ -115,6 +116,12 @@ func (lotp *limitOrderTxProcessor) ExecuteFundingPaymentTx() error {
 	return err
 }
 
+func (lotp *limitOrderTxProcessor) ExecuteSamplePITx() error {
+	txHash, err := lotp.executeLocalTx(lotp.clearingHouseContractAddress, lotp.clearingHouseABI, "samplePI")
+	log.Info("ExecuteSamplePITx", "txHash", txHash.String(), "err", err)
+	return err
+}
+
 func (lotp *limitOrderTxProcessor) ExecuteMatchedOrdersTx(longOrder Order, shortOrder Order, fillAmount *big.Int) error {
 	var err error
 	orders := make([][]byte, 2)
@@ -134,8 +141,8 @@ func (lotp *limitOrderTxProcessor) ExecuteMatchedOrdersTx(longOrder Order, short
 	return err
 }
 
-func (lotp *limitOrderTxProcessor) ExecuteLimitOrderCancel(orders []LimitOrder) error {
-	txHash, err := lotp.executeLocalTx(lotp.orderBookContractAddress, lotp.orderBookABI, "cancelOrders", orders)
+func (lotp *limitOrderTxProcessor) ExecuteLimitOrderCancel(orders []LimitOrderV2) error {
+	txHash, err := lotp.executeLocalTx(lotp.orderBookContractAddress, lotp.orderBookABI, "cancelOrdersWithLowMargin", orders)
 	log.Info("ExecuteLimitOrderCancel", "orders", orders, "txHash", txHash.String(), "err", err)
 	return err
 }


### PR DESCRIPTION
## Why this should be merged
- Adds parsing logic for new events
- Adds new struct LimitOrderV2 similar to LimitOrder
- Adds ExecuteSamplePI
- Adds unit tests for new events
- Prevents matching of post only orders with older orders

## How this was tested
- On local
