### PR TITLE
Make IOC orders great again

### DIFF
--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -225,33 +225,50 @@ func (pipeline *MatchingPipeline) runLiquidations(liquidablePositions []Liquidab
 }
 
 func (pipeline *MatchingPipeline) runMatchingEngine(lotp LimitOrderTxProcessor, longOrders []Order, shortOrders []Order) {
-	if len(longOrders) == 0 || len(shortOrders) == 0 {
-		return
-	}
-
-	matchingComplete := false
 	for i := 0; i < len(longOrders); i++ {
+		// if there are no short orders or if the price of the first long order is < the price of the first short order, then we can stop matching
+		if len(shortOrders) == 0 || longOrders[i].Price.Cmp(shortOrders[0].Price) == -1 {
+			break
+		}
 		numOrdersExhausted := 0
 		for j := 0; j < len(shortOrders); j++ {
-			var ordersMatched bool
-			longOrders[i], shortOrders[j], ordersMatched = matchLongAndShortOrder(lotp, longOrders[i], shortOrders[j])
-			if !ordersMatched {
-				matchingComplete = true
-				break
-
+			fillAmount := areMatchingOrders(longOrders[i], shortOrders[j])
+			if fillAmount == nil {
+				continue
 			}
-			if shortOrders[j].GetUnFilledBaseAssetQuantity().Sign() == 0 {
+			isLongFilled, isShortFilled := ExecuteMatchedOrders(lotp, &longOrders[i], &shortOrders[i], fillAmount)
+			if isShortFilled {
 				numOrdersExhausted++
 			}
-			if longOrders[i].GetUnFilledBaseAssetQuantity().Sign() == 0 {
+			if isLongFilled {
 				break
 			}
-		}
-		if matchingComplete {
-			break
 		}
 		shortOrders = shortOrders[numOrdersExhausted:]
 	}
+}
+
+func areMatchingOrders(longOrder, shortOrder Order) *big.Int {
+	if longOrder.Price.Cmp(shortOrder.Price) == -1 {
+		return nil
+	}
+	blockDiff := longOrder.BlockNumber.Cmp(shortOrder.BlockNumber)
+	if blockDiff == -1 && (longOrder.OrderType == IOCOrderType || shortOrder.isPostOnly()) ||
+		blockDiff == 1 && (shortOrder.OrderType == IOCOrderType || longOrder.isPostOnly()) {
+		return nil
+	}
+	fillAmount := utils.BigIntMinAbs(longOrder.GetUnFilledBaseAssetQuantity(), shortOrder.GetUnFilledBaseAssetQuantity())
+	if fillAmount.Sign() == 0 {
+		return nil
+	}
+	return fillAmount
+}
+
+func ExecuteMatchedOrders(lotp LimitOrderTxProcessor, longOrder, shortOrder *Order, fillAmount *big.Int) (bool, bool) {
+	lotp.ExecuteMatchedOrdersTx(*longOrder, *shortOrder, fillAmount)
+	longOrder.FilledBaseAssetQuantity.Add(longOrder.FilledBaseAssetQuantity, fillAmount)
+	shortOrder.FilledBaseAssetQuantity.Sub(shortOrder.FilledBaseAssetQuantity, fillAmount)
+	return longOrder.FilledBaseAssetQuantity.Sign() == 0, shortOrder.FilledBaseAssetQuantity.Sign() == 0
 }
 
 func matchLongAndShortOrder(lotp LimitOrderTxProcessor, longOrder, shortOrder Order) (Order, Order, bool) {

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -829,34 +829,44 @@ func (db *InMemoryDatabase) getReduceOnlyOrderDisplay(order *Order) *Order {
 	}
 }
 
-func sortLongOrders(orders []Order) []Order {
+func sortLongOrders(orders []Order) {
 	sort.SliceStable(orders, func(i, j int) bool {
-		if orders[i].Price.Cmp(orders[j].Price) == 1 {
+		priceDiff := orders[i].Price.Cmp(orders[j].Price)
+		if priceDiff == 1 {
 			return true
-		}
-		if orders[i].Price.Cmp(orders[j].Price) == 0 {
-			if orders[i].BlockNumber.Cmp(orders[j].BlockNumber) == -1 {
+		} else if priceDiff == 0 {
+			blockDiff := orders[i].BlockNumber.Cmp(orders[j].BlockNumber)
+			if blockDiff == -1 { // i was placed before j
 				return true
+			} else if blockDiff == 0 { // i and j were placed in the same block
+				if orders[i].OrderType == IOCOrderType {
+					// prioritize fulfilling IOC orders first, because they are short lived
+					return true
+				}
 			}
 		}
 		return false
 	})
-	return orders
 }
 
-func sortShortOrders(orders []Order) []Order {
+func sortShortOrders(orders []Order) {
 	sort.SliceStable(orders, func(i, j int) bool {
-		if orders[i].Price.Cmp(orders[j].Price) == -1 {
+		priceDiff := orders[i].Price.Cmp(orders[j].Price)
+		if priceDiff == -1 {
 			return true
-		}
-		if orders[i].Price.Cmp(orders[j].Price) == 0 {
-			if orders[i].BlockNumber.Cmp(orders[j].BlockNumber) == -1 {
+		} else if priceDiff == 0 {
+			blockDiff := orders[i].BlockNumber.Cmp(orders[j].BlockNumber)
+			if blockDiff == -1 { // i was placed before j
 				return true
+			} else if blockDiff == 0 { // i and j were placed in the same block
+				if orders[i].OrderType == IOCOrderType {
+					// prioritize fulfilling IOC orders first, because they are short lived
+					return true
+				}
 			}
 		}
 		return false
 	})
-	return orders
 }
 
 func (db *InMemoryDatabase) GetOrderBookData() InMemoryDatabase {

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -140,7 +140,6 @@ func (lotp *limitOrderTxProcessor) ExecuteMatchedOrdersTx(longOrder Order, short
 		return err
 	}
 
-	// log.Info("ExecuteMatchedOrdersTx", "orders[0]", hex.EncodeToString(orders[0]), "orders[1]", hex.EncodeToString(orders[1]), "fillAmount", prettifyScaledBigInt(fillAmount, 18))
 	txHash, err := lotp.executeLocalTx(lotp.orderBookContractAddress, lotp.orderBookABI, "executeMatchedOrders", orders, fillAmount)
 	log.Info("ExecuteMatchedOrdersTx", "LongOrder", longOrder, "ShortOrder", shortOrder, "fillAmount", prettifyScaledBigInt(fillAmount, 18), "txHash", txHash.String(), "err", err)
 	return err

--- a/precompile/contracts/bibliophile/client.go
+++ b/precompile/contracts/bibliophile/client.go
@@ -16,7 +16,6 @@ type BibliophileClient interface {
 	GetTakerFee() *big.Int
 	//orderbook
 	GetSize(market common.Address, trader *common.Address) *big.Int
-	DetermineFillPrice(marketId int64, longOrderPrice, shortOrderPrice, blockPlaced0, blockPlaced1 *big.Int) (*ValidateOrdersAndDetermineFillPriceOutput, error)
 	DetermineLiquidationFillPrice(marketId int64, baseAssetQuantity, price *big.Int) (*big.Int, error)
 	GetLongOpenOrdersAmount(trader common.Address, ammIndex *big.Int) *big.Int
 	GetShortOpenOrdersAmount(trader common.Address, ammIndex *big.Int) *big.Int
@@ -81,10 +80,6 @@ func (b *bibliophileClient) GetTakerFee() *big.Int {
 
 func (b *bibliophileClient) GetMarketAddressFromMarketID(marketID int64) common.Address {
 	return getMarketAddressFromMarketID(marketID, b.accessibleState.GetStateDB())
-}
-
-func (b *bibliophileClient) DetermineFillPrice(marketId int64, longOrderPrice, shortOrderPrice, blockPlaced0, blockPlaced1 *big.Int) (*ValidateOrdersAndDetermineFillPriceOutput, error) {
-	return DetermineFillPrice(b.accessibleState.GetStateDB(), marketId, longOrderPrice, shortOrderPrice, blockPlaced0, blockPlaced1)
 }
 
 func (b *bibliophileClient) DetermineLiquidationFillPrice(marketId int64, baseAssetQuantity, price *big.Int) (*big.Int, error) {

--- a/precompile/contracts/bibliophile/client.go
+++ b/precompile/contracts/bibliophile/client.go
@@ -16,7 +16,6 @@ type BibliophileClient interface {
 	GetTakerFee() *big.Int
 	//orderbook
 	GetSize(market common.Address, trader *common.Address) *big.Int
-	DetermineLiquidationFillPrice(marketId int64, baseAssetQuantity, price *big.Int) (*big.Int, error)
 	GetLongOpenOrdersAmount(trader common.Address, ammIndex *big.Int) *big.Int
 	GetShortOpenOrdersAmount(trader common.Address, ammIndex *big.Int) *big.Int
 	GetReduceOnlyAmount(trader common.Address, ammIndex *big.Int) *big.Int
@@ -43,6 +42,7 @@ type BibliophileClient interface {
 	GetBidsHead(market common.Address) *big.Int
 	GetAsksHead(market common.Address) *big.Int
 	GetUpperAndLowerBoundForMarket(marketId int64) (*big.Int, *big.Int)
+	GetAcceptableBoundsForLiquidation(marketId int64) (*big.Int, *big.Int)
 
 	GetAccessibleState() contract.AccessibleState
 }
@@ -80,10 +80,6 @@ func (b *bibliophileClient) GetTakerFee() *big.Int {
 
 func (b *bibliophileClient) GetMarketAddressFromMarketID(marketID int64) common.Address {
 	return getMarketAddressFromMarketID(marketID, b.accessibleState.GetStateDB())
-}
-
-func (b *bibliophileClient) DetermineLiquidationFillPrice(marketId int64, baseAssetQuantity, price *big.Int) (*big.Int, error) {
-	return DetermineLiquidationFillPrice(b.accessibleState.GetStateDB(), marketId, baseAssetQuantity, price)
 }
 
 func (b *bibliophileClient) GetBlockPlaced(orderHash [32]byte) *big.Int {
@@ -148,6 +144,10 @@ func (b *bibliophileClient) GetImpactMarginNotional(ammAddress common.Address) *
 
 func (b *bibliophileClient) GetUpperAndLowerBoundForMarket(marketId int64) (*big.Int, *big.Int) {
 	return GetAcceptableBounds(b.accessibleState.GetStateDB(), marketId)
+}
+
+func (b *bibliophileClient) GetAcceptableBoundsForLiquidation(marketId int64) (*big.Int, *big.Int) {
+	return GetAcceptableBoundsForLiquidation(b.accessibleState.GetStateDB(), marketId)
 }
 
 func (b *bibliophileClient) GetBidsHead(market common.Address) *big.Int {

--- a/precompile/contracts/juror/logic.go
+++ b/precompile/contracts/juror/logic.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ava-labs/subnet-evm/accounts/abi"
 	"github.com/ava-labs/subnet-evm/plugin/evm/orderbook"
 	b "github.com/ava-labs/subnet-evm/precompile/contracts/bibliophile"
+	"github.com/ava-labs/subnet-evm/utils"
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -18,6 +19,7 @@ type OrderType uint8
 const (
 	Limit OrderType = iota
 	IOC
+	PostOnly
 )
 
 type DecodeStep struct {
@@ -32,6 +34,7 @@ type Metadata struct {
 	Price             *big.Int
 	BlockPlaced       *big.Int
 	OrderHash         common.Hash
+	OrderType         OrderType
 }
 
 type Side uint8
@@ -76,6 +79,7 @@ var (
 	ErrStaleReduceOnlyOrders              = errors.New("cancel stale reduce only orders")
 	ErrInsufficientMargin                 = errors.New("insufficient margin")
 	ErrCrossingMarket                     = errors.New("crossing market")
+	ErrIOCOrderExpired                    = errors.New("IOC order expired")
 	ErrOpenOrders                         = errors.New("open orders")
 	ErrOpenReduceOnlyOrders               = errors.New("open reduce only orders")
 	ErrNoTradingAuthority                 = errors.New("no trading authority")
@@ -122,10 +126,7 @@ func ValidateOrdersAndDetermineFillPrice(bibliophile b.BibliophileClient, inputS
 		return nil, ErrNotMultiple
 	}
 
-	fillPriceAndModes, err := bibliophile.DetermineFillPrice(m0.AmmIndex.Int64(), m0.Price, m1.Price, m0.BlockPlaced, m1.BlockPlaced)
-	if err != nil {
-		return nil, err
-	}
+	fillPriceAndModes, err := DetermineFillPrice(bibliophile, m0, m1)
 
 	output := &ValidateOrdersAndDetermineFillPriceOutput{
 		Instructions: [2]IClearingHouseInstruction{
@@ -133,13 +134,13 @@ func ValidateOrdersAndDetermineFillPrice(bibliophile b.BibliophileClient, inputS
 				AmmIndex:  m0.AmmIndex,
 				Trader:    m0.Trader,
 				OrderHash: m0.OrderHash,
-				Mode:      fillPriceAndModes.Mode0,
+				Mode:      uint8(fillPriceAndModes.Mode0),
 			},
 			IClearingHouseInstruction{
 				AmmIndex:  m1.AmmIndex,
 				Trader:    m1.Trader,
 				OrderHash: m1.OrderHash,
-				Mode:      fillPriceAndModes.Mode1,
+				Mode:      uint8(fillPriceAndModes.Mode1),
 			},
 		},
 		OrderTypes: [2]uint8{uint8(decodeStep0.OrderType), uint8(decodeStep1.OrderType)},
@@ -150,6 +151,69 @@ func ValidateOrdersAndDetermineFillPrice(bibliophile b.BibliophileClient, inputS
 		FillPrice: fillPriceAndModes.FillPrice,
 	}
 	return output, nil
+}
+
+type executionMode uint8
+
+// DO NOT change this ordering because it is critical for the clearing house to determine the correct fill mode
+const (
+	Taker executionMode = iota
+	Maker
+)
+
+type FillPriceAndModes struct {
+	FillPrice *big.Int
+	Mode0     executionMode
+	Mode1     executionMode
+}
+
+func DetermineFillPrice(bibliophile b.BibliophileClient, m0, m1 *Metadata) (*FillPriceAndModes, error) {
+	output := FillPriceAndModes{}
+	upperBound, lowerBound := bibliophile.GetUpperAndLowerBoundForMarket(m0.AmmIndex.Int64())
+	blockDiff := m0.BlockPlaced.Cmp(m1.BlockPlaced)
+	if blockDiff == -1 {
+		// order0 came first, can't be IOC order
+		if m0.OrderType == IOC {
+			return nil, ErrIOCOrderExpired
+		}
+		// order1 came second, can't be post only order
+		if m1.OrderType == PostOnly {
+			return nil, ErrCrossingMarket
+		}
+		output.Mode0 = Maker
+		output.Mode1 = Taker
+	} else if blockDiff == 1 {
+		// order1 came first, can't be IOC order
+		if m1.OrderType == IOC {
+			return nil, ErrIOCOrderExpired
+		}
+		// order0 came second, can't be post only order
+		if m0.OrderType == PostOnly {
+			return nil, ErrCrossingMarket
+		}
+		output.Mode0 = Taker
+		output.Mode1 = Maker
+	} else {
+		// both orders were placed in same block
+		if m1.OrderType == IOC {
+			// order1 is IOC, order0 is Limit or post only
+			output.Mode0 = Maker
+			output.Mode1 = Taker
+		} else {
+			// scenarios:
+			// 1. order0 is IOC, order1 is Limit or post only
+			// 2. both order0 and order1 are Limit or post only (in that scenario we default to long being the taker order, which can sometimes result in a better execution price for them)
+			output.Mode0 = Taker
+			output.Mode1 = Maker
+		}
+	}
+
+	if output.Mode0 == Maker {
+		output.FillPrice = utils.BigIntMin(m0.Price, upperBound)
+	} else {
+		output.FillPrice = utils.BigIntMax(m1.Price, lowerBound)
+	}
+	return &output, nil
 }
 
 func ValidateLiquidationOrderAndDetermineFillPrice(bibliophile b.BibliophileClient, inputStruct *ValidateLiquidationOrderAndDetermineFillPriceInput) (*ValidateLiquidationOrderAndDetermineFillPriceOutput, error) {
@@ -186,7 +250,7 @@ func ValidateLiquidationOrderAndDetermineFillPrice(bibliophile b.BibliophileClie
 			AmmIndex:  m0.AmmIndex,
 			Trader:    m0.Trader,
 			OrderHash: m0.OrderHash,
-			Mode:      1, // Maker
+			Mode:      uint8(Maker),
 		},
 		OrderType:    uint8(decodeStep0.OrderType),
 		EncodedOrder: decodeStep0.EncodedOrder,
@@ -219,7 +283,13 @@ func validateOrder(bibliophile b.BibliophileClient, orderType OrderType, encoded
 		if err != nil {
 			return nil, err
 		}
-		return validateExecuteLimitOrder(bibliophile, order, side, fillAmount, orderHash)
+		metadata, err := validateExecuteLimitOrder(bibliophile, order, side, fillAmount, orderHash)
+		if order.PostOnly {
+			metadata.OrderType = PostOnly
+		}
+		if err != nil {
+			return nil, err
+		}
 	}
 	if orderType == IOC {
 		order, err := orderbook.DecodeIOCOrder(encodedOrder)
@@ -244,6 +314,7 @@ func validateExecuteLimitOrder(bibliophile b.BibliophileClient, order *orderbook
 		BlockPlaced:       bibliophile.GetBlockPlaced(orderHash),
 		Price:             order.Price,
 		OrderHash:         orderHash,
+		OrderType:         Limit,
 	}, nil
 }
 
@@ -384,6 +455,7 @@ func validateExecuteIOCOrder(bibliophile b.BibliophileClient, order *orderbook.I
 		BlockPlaced:       bibliophile.IOC_GetBlockPlaced(orderHash),
 		Price:             order.Price,
 		OrderHash:         orderHash,
+		OrderType:         IOC,
 	}, nil
 }
 


### PR DESCRIPTION
## Why this should be merged
- This PR makes IOC orders truly "Immediate Or Cancel". IOC orders placed in block n can't be matched with an order placed in block >= n+1.
