### PR TITLE
Prevent duplicate match transactions

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -296,12 +296,12 @@ type TxPool struct {
 	locals  *accountSet // Set of local transaction to exempt from eviction rules
 	journal *journal    // Journal of local transaction to back up to disk
 
-	OrderBookTxMap map[common.Address]*list
-	pending        map[common.Address]*list     // All currently processable transactions
-	queue          map[common.Address]*list     // Queued but non-processable transactions
-	beats          map[common.Address]time.Time // Last heartbeat from each known account
-	all            *lookup                      // All transactions to allow lookups
-	priced         *pricedList                  // All transactions sorted by price
+	orderBookTxs OrderBookTxs
+	pending      map[common.Address]*list     // All currently processable transactions
+	queue        map[common.Address]*list     // Queued but non-processable transactions
+	beats        map[common.Address]time.Time // Last heartbeat from each known account
+	all          *lookup                      // All transactions to allow lookups
+	priced       *pricedList                  // All transactions sorted by price
 
 	chainHeadCh         chan core.ChainHeadEvent
 	chainHeadSub        event.Subscription
@@ -318,6 +318,11 @@ type TxPool struct {
 	changesSinceReorg int // A counter for how many drops we've performed in-between reorg.
 }
 
+type OrderBookTxs struct {
+	txs         map[common.Address]*list
+	blockNumber uint64
+}
+
 type txpoolResetRequest struct {
 	oldHead, newHead *types.Header
 }
@@ -328,13 +333,17 @@ func NewTxPool(config Config, chainconfig *params.ChainConfig, chain blockChain)
 	// Sanitize the input to ensure no vulnerable gas prices are set
 	config = (&config).sanitize()
 
+	orderBookTxs := OrderBookTxs{
+		txs: make(map[common.Address]*list),
+	}
+
 	// Create the transaction pool with its initial settings
 	pool := &TxPool{
 		config:              config,
 		chainconfig:         chainconfig,
 		chain:               chain,
 		signer:              types.LatestSigner(chainconfig),
-		OrderBookTxMap:      make(map[common.Address]*list),
+		orderBookTxs:        orderBookTxs,
 		pending:             make(map[common.Address]*list),
 		queue:               make(map[common.Address]*list),
 		beats:               make(map[common.Address]time.Time),
@@ -1045,7 +1054,7 @@ func (pool *TxPool) GetOrderBookTxs() map[common.Address]types.Transactions {
 	defer pool.mu.RUnlock()
 
 	txs := map[common.Address]types.Transactions{}
-	for from, txList := range pool.OrderBookTxMap {
+	for from, txList := range pool.orderBookTxs.txs {
 		txs[from] = txList.Flatten()
 	}
 	return txs
@@ -1056,7 +1065,7 @@ func (pool *TxPool) GetOrderBookTxsCount() uint64 {
 	defer pool.mu.RUnlock()
 
 	count := 0
-	for _, txList := range pool.OrderBookTxMap {
+	for _, txList := range pool.orderBookTxs.txs {
 		count += txList.Len()
 	}
 	return uint64(count)
@@ -1066,14 +1075,16 @@ func (pool *TxPool) PurgeOrderBookTxs() {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
-	for from, _ := range pool.OrderBookTxMap {
-		delete(pool.OrderBookTxMap, from)
+	for from, _ := range pool.orderBookTxs.txs {
+		delete(pool.orderBookTxs.txs, from)
 	}
+
+	pool.orderBookTxs.blockNumber = 0
 }
 
 func (pool *TxPool) GetOrderBookTxNonce(address common.Address) uint64 {
 	nonce := pool.Nonce(address)
-	val, ok := pool.OrderBookTxMap[address]
+	val, ok := pool.orderBookTxs.txs[address]
 	if ok {
 		return nonce + uint64(val.Len())
 	}
@@ -1085,10 +1096,10 @@ func (pool *TxPool) AddOrderBookTx(tx *types.Transaction) error {
 	defer pool.mu.Unlock()
 
 	if from, err := types.Sender(pool.signer, tx); err == nil {
-		val, ok := pool.OrderBookTxMap[from]
+		val, ok := pool.orderBookTxs.txs[from]
 		if !ok {
 			val = newList(false)
-			pool.OrderBookTxMap[from] = val
+			pool.orderBookTxs.txs[from] = val
 		}
 		ok, _ = val.Add(tx, 0)
 		if !ok {
@@ -1098,6 +1109,20 @@ func (pool *TxPool) AddOrderBookTx(tx *types.Transaction) error {
 		return fmt.Errorf("AddOrderBookTx: error getting sender: %w", err)
 	}
 	return nil
+}
+
+func (pool *TxPool) SetOrderBookTxsHeadBlockNumber(blockNumber uint64) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	pool.orderBookTxs.blockNumber = blockNumber
+}
+
+func (pool *TxPool) GetOrderBookTxsHeadBlockNumber() uint64 {
+	pool.mu.RLock()
+	defer pool.mu.RUnlock()
+
+	return pool.orderBookTxs.blockNumber
 }
 
 // AddLocals enqueues a batch of transactions into the pool if they are valid, marking the

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -86,6 +86,9 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	}
 
 	orderBookTxsCount := pipeline.lotp.GetOrderBookTxsCount()
+	if orderBookTxsCount > 0 {
+		pipeline.lotp.SetOrderBookTxsHeadBlockNumber(blockNumber.Uint64())
+	}
 	return orderBookTxsCount > 0
 }
 

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -167,6 +167,10 @@ func (lotp *MockLimitOrderTxProcessor) PurgeOrderBookTxs() {
 	lotp.Called()
 }
 
+func (lotp *MockLimitOrderTxProcessor) SetOrderBookTxsHeadBlockNumber(blockNumber uint64) {
+	lotp.Called()
+}
+
 func (lotp *MockLimitOrderTxProcessor) GetOrderBookTxsCount() uint64 {
 	args := lotp.Called()
 	return uint64(args.Int(0))

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -30,6 +30,7 @@ var IOCOrderBookContractAddress = common.HexToAddress("0x03000000000000000000000
 
 type LimitOrderTxProcessor interface {
 	GetOrderBookTxsCount() uint64
+	SetOrderBookTxsHeadBlockNumber(blockNumber uint64)
 	PurgeOrderBookTxs()
 	ExecuteMatchedOrdersTx(incomingOrder Order, matchedOrder Order, fillAmount *big.Int) error
 	ExecuteFundingPaymentTx() error
@@ -228,6 +229,10 @@ func (lotp *limitOrderTxProcessor) PurgeOrderBookTxs() {
 
 func (lotp *limitOrderTxProcessor) GetOrderBookTxsCount() uint64 {
 	return lotp.txPool.GetOrderBookTxsCount()
+}
+
+func (lotp *limitOrderTxProcessor) SetOrderBookTxsHeadBlockNumber(blockNumber uint64) {
+	lotp.txPool.SetOrderBookTxsHeadBlockNumber(blockNumber)
 }
 
 func getPositionTypeBasedOnBaseAssetQuantity(baseAssetQuantity *big.Int) PositionType {


### PR DESCRIPTION
## Why this should be merged
Save the current head block number while adding matching txs to mempool. When buildBlock is called then match the current head block number with the saved head block number in mempool. If the current head block is ahead of saved head block, then purge the orderbook txs from mempool and continue.

## How this was tested
On local
