### PR TITLE
Mid price

### DIFF
--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -18,6 +18,7 @@ type IConfigService interface {
 	getMinSizeRequirement(market Market) *big.Int
 	GetActiveMarketsCount() int64
 	GetUnderlyingPrices() []*big.Int
+	GetMidPrices() []*big.Int
 	GetCollaterals() []hu.Collateral
 	GetLastPremiumFraction(market Market, trader *common.Address) *big.Int
 	GetCumulativePremiumFraction(market Market) *big.Int
@@ -82,6 +83,10 @@ func (cs *ConfigService) GetActiveMarketsCount() int64 {
 
 func (cs *ConfigService) GetUnderlyingPrices() []*big.Int {
 	return bibliophile.GetUnderlyingPrices(cs.getStateAtCurrentBlock())
+}
+
+func (cs *ConfigService) GetMidPrices() []*big.Int {
+	return bibliophile.GetMidPrices(cs.getStateAtCurrentBlock())
 }
 
 func (cs *ConfigService) GetCollaterals() []hu.Collateral {

--- a/plugin/evm/orderbook/hubbleutils/data_structures.go
+++ b/plugin/evm/orderbook/hubbleutils/data_structures.go
@@ -23,9 +23,6 @@ type Market = int
 type Position struct {
 	OpenNotional *big.Int `json:"open_notional"`
 	Size         *big.Int `json:"size"`
-	// UnrealisedFunding    *big.Int `json:"unrealised_funding"`
-	// LastPremiumFraction  *big.Int `json:"last_premium_fraction"`
-	// LiquidationThreshold *big.Int `json:"liquidation_threshold"`
 }
 
 type Trader struct {

--- a/plugin/evm/orderbook/hubbleutils/margin_math.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math.go
@@ -8,7 +8,7 @@ import (
 type HubbleState struct {
 	Assets             []Collateral
 	OraclePrices       map[Market]*big.Int
-	LastPrices         map[Market]*big.Int
+	MidPrices          map[Market]*big.Int
 	ActiveMarkets      []Market
 	MinAllowableMargin *big.Int
 	MaintenanceMargin  *big.Int
@@ -63,7 +63,7 @@ func GetOptimalPnl(hState *HubbleState, position *Position, margin *big.Int, mar
 
 	// based on last price
 	notionalPosition, unrealizedPnl, lastPriceBasedMF := GetPositionMetadata(
-		hState.LastPrices[market],
+		hState.MidPrices[market],
 		position.OpenNotional,
 		position.Size,
 		margin,

--- a/plugin/evm/orderbook/hubbleutils/margin_math.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math.go
@@ -62,7 +62,7 @@ func GetOptimalPnl(hState *HubbleState, position *Position, margin *big.Int, mar
 	}
 
 	// based on last price
-	notionalPosition, unrealizedPnl, lastPriceBasedMF := GetPositionMetadata(
+	notionalPosition, unrealizedPnl, midPriceBasedMF := GetPositionMetadata(
 		hState.MidPrices[market],
 		position.OpenNotional,
 		position.Size,
@@ -77,8 +77,8 @@ func GetOptimalPnl(hState *HubbleState, position *Position, margin *big.Int, mar
 		margin,
 	)
 
-	if (marginMode == Maintenance_Margin && oracleBasedMF.Cmp(lastPriceBasedMF) == 1) || // for liquidations
-		(marginMode == Min_Allowable_Margin && oracleBasedMF.Cmp(lastPriceBasedMF) == -1) { // for increasing leverage
+	if (marginMode == Maintenance_Margin && oracleBasedMF.Cmp(midPriceBasedMF) == 1) || // for liquidations
+		(marginMode == Min_Allowable_Margin && oracleBasedMF.Cmp(midPriceBasedMF) == -1) { // for increasing leverage
 		return oracleBasedNotional, oracleBasedUnrealizedPnl
 	}
 	return notionalPosition, unrealizedPnl

--- a/plugin/evm/orderbook/hubbleutils/margin_math.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math.go
@@ -90,7 +90,7 @@ func GetPositionMetadata(price *big.Int, openNotional *big.Int, size *big.Int, m
 	if notionalPosition.Sign() == 0 {
 		return big.NewInt(0), big.NewInt(0), big.NewInt(0)
 	}
-	if size.Cmp(big.NewInt(0)) > 0 {
+	if size.Sign() > 0 {
 		uPnL = Sub(notionalPosition, openNotional)
 	} else {
 		uPnL = Sub(openNotional, notionalPosition)

--- a/plugin/evm/orderbook/hubbleutils/margin_math_test.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math_test.go
@@ -1,0 +1,134 @@
+package hubbleutils
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWeightedAndSpotCollateral(t *testing.T) {
+	assets := []Collateral{
+		{
+			Price:    big.NewInt(80500000), // 80.5
+			Weight:   big.NewInt(800000),   // 0.8
+			Decimals: 6,
+		},
+		{
+			Price:    big.NewInt(410000), // 0.41
+			Weight:   big.NewInt(900000), // 0.9
+			Decimals: 6,
+		},
+	}
+	margins := []*big.Int{
+		big.NewInt(3500000),    // 3.5
+		big.NewInt(1040000000), // 1040
+	}
+	expectedWeighted := big.NewInt(609160000) // 609.16
+	expectedSpot := big.NewInt(708150000)     // 708.15
+	resultWeighted, resultSpot := WeightedAndSpotCollateral(assets, margins)
+	fmt.Println(resultWeighted, resultSpot)
+	assert.Equal(t, expectedWeighted, resultWeighted)
+	assert.Equal(t, expectedSpot, resultSpot)
+
+	normalisedMargin := GetNormalizedMargin(assets, margins)
+	assert.Equal(t, expectedWeighted, normalisedMargin)
+
+}
+
+func TestGetNotionalPosition(t *testing.T) {
+	price := Scale(big.NewInt(1200), 6)
+	size := Scale(big.NewInt(5), 18)
+	expected := Scale(big.NewInt(6000), 6)
+
+	result := GetNotionalPosition(price, size)
+
+	assert.Equal(t, expected, result)
+}
+
+func TestGetPositionMetadata(t *testing.T) {
+	price := big.NewInt(20250000)        // 20.25
+	openNotional := big.NewInt(75369000) // 75.369 (size * 18.5)
+	size := Scale(big.NewInt(40740), 14) // 4.074
+	margin := big.NewInt(20000000)       // 20
+
+	notionalPosition, unrealisedPnl, marginFraction := GetPositionMetadata(price, openNotional, size, margin)
+
+	expectedNotionalPosition := big.NewInt(82498500) // 82.4985
+	expectedUnrealisedPnl := big.NewInt(7129500)     // 7.1295
+	expectedMarginFraction := big.NewInt(328848)     // 0.328848
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUnrealisedPnl, unrealisedPnl)
+	assert.Equal(t, expectedMarginFraction, marginFraction)
+
+	// ------ when size is negative ------
+	size = Scale(big.NewInt(-40740), 14) // -4.074
+	openNotional = big.NewInt(75369000)  // 75.369 (size * 18.5)
+	notionalPosition, unrealisedPnl, marginFraction = GetPositionMetadata(price, openNotional, size, margin)
+	fmt.Println("notionalPosition", notionalPosition, "unrealisedPnl", unrealisedPnl, "marginFraction", marginFraction)
+
+	expectedNotionalPosition = big.NewInt(82498500) // 82.4985
+	expectedUnrealisedPnl = big.NewInt(-7129500)    // -7.1295
+	expectedMarginFraction = big.NewInt(156008)     // 0.156008
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUnrealisedPnl, unrealisedPnl)
+	assert.Equal(t, expectedMarginFraction, marginFraction)
+}
+
+func TestGetOptimalPnl(t *testing.T) {
+	hState := &HubbleState{
+		Assets: []Collateral{
+			{
+				Price:    big.NewInt(101000000), // 101
+				Weight:   big.NewInt(900000),    // 0.9
+				Decimals: 6,
+			},
+			{
+				Price:    big.NewInt(54360000), // 54.36
+				Weight:   big.NewInt(700000),   // 0.7
+				Decimals: 6,
+			},
+		},
+		MidPrices: map[Market]*big.Int{
+			0: big.NewInt(1545340000), // 1545.34
+		},
+		OraclePrices: map[Market]*big.Int{
+			0: big.NewInt(1545210000), // 1545.21
+		},
+		ActiveMarkets: []Market{
+			0,
+		},
+		MinAllowableMargin: big.NewInt(100000), // 0.1
+		MaintenanceMargin:  big.NewInt(200000), // 0.2
+	}
+	position := &Position{
+		Size:         Scale(big.NewInt(582), 14), // 0.0582
+		OpenNotional: big.NewInt(87500000),       // 87.5
+	}
+	margin := big.NewInt(20000000) // 20
+	market := 0
+	marginMode := Maintenance_Margin
+
+	notionalPosition, uPnL := GetOptimalPnl(hState, position, margin, market, marginMode)
+
+	expectedNotionalPosition := big.NewInt(89938788)
+	expectedUPnL := big.NewInt(2438788)
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUPnL, uPnL)
+
+	// ------ when marginMode is Min_Allowable_Margin ------
+
+	marginMode = Min_Allowable_Margin
+
+	notionalPosition, uPnL = GetOptimalPnl(hState, position, margin, market, marginMode)
+
+	expectedNotionalPosition = big.NewInt(89931222)
+	expectedUPnL = big.NewInt(2431222)
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUPnL, uPnL)
+}

--- a/plugin/evm/orderbook/liquidations.go
+++ b/plugin/evm/orderbook/liquidations.go
@@ -27,7 +27,7 @@ func calcMarginFraction(trader *Trader, hState *hu.HubbleState) *big.Int {
 		Positions:      translatePositions(trader.Positions),
 		Margins:        getMargins(trader, len(hState.Assets)),
 		PendingFunding: getTotalFunding(trader, hState.ActiveMarkets),
-		ReservedMargin: trader.Margin.Reserved,
+		ReservedMargin: new(big.Int).Set(trader.Margin.Reserved),
 	}
 	return hu.GetMarginFraction(hState, userState)
 }

--- a/plugin/evm/orderbook/liquidations.go
+++ b/plugin/evm/orderbook/liquidations.go
@@ -67,7 +67,7 @@ func getTotalNotionalPositionAndUnrealizedPnl(trader *Trader, margin *big.Int, m
 	return hu.GetTotalNotionalPositionAndUnrealizedPnl(
 		&hu.HubbleState{
 			OraclePrices:  oraclePrices,
-			LastPrices:    lastPrices,
+			MidPrices:    lastPrices,
 			ActiveMarkets: markets,
 		},
 		&hu.UserState{

--- a/plugin/evm/orderbook/liquidations_test.go
+++ b/plugin/evm/orderbook/liquidations_test.go
@@ -15,8 +15,12 @@ func TestGetLiquidableTraders(t *testing.T) {
 	assets := []hu.Collateral{{Price: big.NewInt(1e6), Weight: big.NewInt(1e6), Decimals: 6}}
 	t.Run("When no trader exist", func(t *testing.T) {
 		db := getDatabase()
-		oraclePrices := map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))}
-		liquidablePositions, _ := db.GetNaughtyTraders(oraclePrices, assets, []Market{market})
+		hState := &hu.HubbleState{
+			Assets:        assets,
+			OraclePrices:  map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))},
+			ActiveMarkets: []hu.Market{market},
+		}
+		liquidablePositions, _ := db.GetNaughtyTraders(hState)
 		assert.Equal(t, 0, len(liquidablePositions))
 	})
 
@@ -33,9 +37,14 @@ func TestGetLiquidableTraders(t *testing.T) {
 				Positions: map[Market]*Position{},
 			},
 		}
-		db.LastPrice = map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(100))}
-		oraclePrices := map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))}
-		liquidablePositions, _ := db.GetNaughtyTraders(oraclePrices, assets, []Market{market})
+		hState := &hu.HubbleState{
+			Assets:            assets,
+			OraclePrices:      map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))},
+			LastPrices:        map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(100))},
+			ActiveMarkets:     []hu.Market{market},
+			MaintenanceMargin: db.configService.getMaintenanceMargin(),
+		}
+		liquidablePositions, _ := db.GetNaughtyTraders(hState)
 		assert.Equal(t, 0, len(liquidablePositions))
 	})
 
@@ -61,9 +70,16 @@ func TestGetLiquidableTraders(t *testing.T) {
 			db.TraderMap = map[common.Address]*Trader{
 				longTraderAddress: &longTrader,
 			}
-			db.LastPrice = map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))}
-			oraclePrices := map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))}
 
+			hState := &hu.HubbleState{
+				Assets:             assets,
+				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))},
+				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))},
+				ActiveMarkets:      []hu.Market{market},
+				MinAllowableMargin: db.configService.getMinAllowableMargin(),
+				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
+			}
+			oraclePrices := hState.OraclePrices
 			// assertions begin
 			// for long trader
 			_trader := &longTrader
@@ -75,23 +91,25 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price: notional = 49 * 10 = 490, pnl = 490-900 = -410, mf = (500-42-410)/490 = 0.097
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence orale_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(490)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-410)), unrealizePnL)
 
-			availableMargin := getAvailableMargin(_trader, pendingFundingLong, assets, oraclePrices, db.GetLastPrices(), db.configService.getMinAllowableMargin(), []Market{market})
+			hState.MinAllowableMargin = db.configService.getMinAllowableMargin()
+			availableMargin := getAvailableMargin(_trader, hState)
 			// availableMargin = 500 - 42 (pendingFundingLong) - 410 (uPnL) - 490/5 = -50
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-50)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, last_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(500)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-400)), unrealizePnL)
 
-			marginFraction := calcMarginFraction(_trader, pendingFundingLong, assets, oraclePrices, db.GetLastPrices(), []Market{market})
+			// marginFraction := calcMarginFraction(_trader, pendingFundingLong, assets, oraclePrices, hState.LastPrices, []Market{market})
+			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginLong, pendingFundingLong), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(oraclePrices, assets, []Market{market})
+			liquidablePositions, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 
@@ -110,8 +128,15 @@ func TestGetLiquidableTraders(t *testing.T) {
 			db.TraderMap = map[common.Address]*Trader{
 				longTraderAddress: &longTrader,
 			}
-			db.LastPrice = map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))}
-			oraclePrices := map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))}
+			hState := &hu.HubbleState{
+				Assets:             assets,
+				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))},
+				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))},
+				ActiveMarkets:      []hu.Market{market},
+				MinAllowableMargin: db.configService.getMinAllowableMargin(),
+				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
+			}
+			oraclePrices := hState.OraclePrices
 
 			// assertions begin
 			// for long trader
@@ -124,23 +149,23 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price: notional = 50 * 10 = 500, pnl = 500-900 = -400, mf = (500-42-400)/500 = 0.116
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence last_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(490)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-410)), unrealizePnL)
 
-			availableMargin := getAvailableMargin(_trader, pendingFundingLong, assets, oraclePrices, db.GetLastPrices(), db.configService.getMinAllowableMargin(), []Market{market})
+			availableMargin := getAvailableMargin(_trader, hState)
 			// availableMargin = 500 - 42 (pendingFundingLong) - 410 (uPnL) - 490/5 = -50
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-50)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, oracle_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(500)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-400)), unrealizePnL)
 
-			marginFraction := calcMarginFraction(_trader, pendingFundingLong, assets, oraclePrices, db.GetLastPrices(), []Market{market})
+			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginLong, pendingFundingLong), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(oraclePrices, assets, []Market{market})
+			liquidablePositions, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 	})
@@ -167,8 +192,15 @@ func TestGetLiquidableTraders(t *testing.T) {
 			db.TraderMap = map[common.Address]*Trader{
 				shortTraderAddress: &shortTrader,
 			}
-			db.LastPrice = map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))}
-			oraclePrices := map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))}
+			hState := &hu.HubbleState{
+				Assets:             assets,
+				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))},
+				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))},
+				ActiveMarkets:      []hu.Market{market},
+				MinAllowableMargin: db.configService.getMinAllowableMargin(),
+				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
+			}
+			oraclePrices := hState.OraclePrices
 
 			// assertions begin
 			_trader := &shortTrader
@@ -180,23 +212,23 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price based notional = 143 * 20 = 2860, pnl = 2100-2860 = -760, mf = (1000+37-760)/2860 = 0.096
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence, oracle_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2860)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-760)), unrealizePnL)
 
-			availableMargin := getAvailableMargin(_trader, pendingFundingShort, assets, oraclePrices, db.GetLastPrices(), db.configService.getMinAllowableMargin(), []Market{market})
+			availableMargin := getAvailableMargin(_trader, hState)
 			// availableMargin = 1000 + 37 (pendingFundingShort) -760 (uPnL) - 2860/5 = -295
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-295)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, last_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2840)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-740)), unrealizePnL)
 
-			marginFraction := calcMarginFraction(_trader, pendingFundingShort, assets, oraclePrices, db.GetLastPrices(), []Market{market})
+			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginShort, pendingFundingShort), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(oraclePrices, assets, []Market{market})
+			liquidablePositions, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 
@@ -215,8 +247,15 @@ func TestGetLiquidableTraders(t *testing.T) {
 			db.TraderMap = map[common.Address]*Trader{
 				shortTraderAddress: &shortTrader,
 			}
-			db.LastPrice = map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))}
-			oraclePrices := map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))}
+			hState := &hu.HubbleState{
+				Assets:             assets,
+				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))},
+				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))},
+				ActiveMarkets:      []hu.Market{market},
+				MinAllowableMargin: db.configService.getMinAllowableMargin(),
+				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
+			}
+			oraclePrices := hState.OraclePrices
 
 			// assertions begin
 			_trader := &shortTrader
@@ -228,23 +267,23 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price: notional = 142 * 20 = 2840, pnl = 2100-2840 = -740, mf = (1000+37-740)/2840 = 0.104
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence, last_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2860)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-760)), unrealizePnL)
 
-			availableMargin := getAvailableMargin(_trader, pendingFundingShort, assets, oraclePrices, db.GetLastPrices(), db.configService.getMinAllowableMargin(), []Market{market})
+			availableMargin := getAvailableMargin(_trader, hState)
 			// availableMargin = 1000 + 37 (pendingFundingShort) - 760 (uPnL) - 2860/5 = -295
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-295)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, oracle_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, db.GetLastPrices(), []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2840)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-740)), unrealizePnL)
 
-			marginFraction := calcMarginFraction(_trader, pendingFundingShort, assets, oraclePrices, db.GetLastPrices(), []Market{market})
+			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginShort, pendingFundingShort), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(oraclePrices, assets, []Market{market})
+			liquidablePositions, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 	})

--- a/plugin/evm/orderbook/liquidations_test.go
+++ b/plugin/evm/orderbook/liquidations_test.go
@@ -40,7 +40,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 		hState := &hu.HubbleState{
 			Assets:            assets,
 			OraclePrices:      map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))},
-			LastPrices:        map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(100))},
+			MidPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(100))},
 			ActiveMarkets:     []hu.Market{market},
 			MaintenanceMargin: db.configService.getMaintenanceMargin(),
 		}
@@ -74,7 +74,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			hState := &hu.HubbleState{
 				Assets:             assets,
 				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))},
-				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))},
+				MidPrices:          map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))},
 				ActiveMarkets:      []hu.Market{market},
 				MinAllowableMargin: db.configService.getMinAllowableMargin(),
 				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
@@ -91,7 +91,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price: notional = 49 * 10 = 490, pnl = 490-900 = -410, mf = (500-42-410)/490 = 0.097
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence orale_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(490)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-410)), unrealizePnL)
 
@@ -101,11 +101,11 @@ func TestGetLiquidableTraders(t *testing.T) {
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-50)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, last_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(500)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-400)), unrealizePnL)
 
-			// marginFraction := calcMarginFraction(_trader, pendingFundingLong, assets, oraclePrices, hState.LastPrices, []Market{market})
+			// marginFraction := calcMarginFraction(_trader, pendingFundingLong, assets, oraclePrices, hState.MidPrices, []Market{market})
 			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginLong, pendingFundingLong), unrealizePnL)), notionalPosition), marginFraction)
 
@@ -131,7 +131,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			hState := &hu.HubbleState{
 				Assets:             assets,
 				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))},
-				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))},
+				MidPrices:          map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))},
 				ActiveMarkets:      []hu.Market{market},
 				MinAllowableMargin: db.configService.getMinAllowableMargin(),
 				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
@@ -149,7 +149,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price: notional = 50 * 10 = 500, pnl = 500-900 = -400, mf = (500-42-400)/500 = 0.116
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence last_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Min_Allowable_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(490)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-410)), unrealizePnL)
 
@@ -158,7 +158,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-50)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, oracle_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginLong, pendingFundingLong), hu.Maintenance_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(500)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-400)), unrealizePnL)
 
@@ -195,7 +195,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			hState := &hu.HubbleState{
 				Assets:             assets,
 				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))},
-				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))},
+				MidPrices:          map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))},
 				ActiveMarkets:      []hu.Market{market},
 				MinAllowableMargin: db.configService.getMinAllowableMargin(),
 				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
@@ -212,7 +212,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price based notional = 143 * 20 = 2860, pnl = 2100-2860 = -760, mf = (1000+37-760)/2860 = 0.096
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence, oracle_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2860)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-760)), unrealizePnL)
 
@@ -221,7 +221,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-295)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, last_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2840)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-740)), unrealizePnL)
 
@@ -250,7 +250,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			hState := &hu.HubbleState{
 				Assets:             assets,
 				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))},
-				LastPrices:         map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))},
+				MidPrices:          map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))},
 				ActiveMarkets:      []hu.Market{market},
 				MinAllowableMargin: db.configService.getMinAllowableMargin(),
 				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
@@ -267,7 +267,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			// oracle price: notional = 142 * 20 = 2840, pnl = 2100-2840 = -740, mf = (1000+37-740)/2840 = 0.104
 
 			// for hu.Min_Allowable_Margin we select the min of 2 hence, last_mf
-			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Min_Allowable_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2860)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-760)), unrealizePnL)
 
@@ -276,7 +276,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-295)), availableMargin)
 
 			// for hu.Maintenance_Margin we select the max of 2 hence, oracle_mf
-			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, hState.LastPrices, []Market{market})
+			notionalPosition, unrealizePnL = getTotalNotionalPositionAndUnrealizedPnl(_trader, new(big.Int).Add(marginShort, pendingFundingShort), hu.Maintenance_Margin, oraclePrices, hState.MidPrices, []Market{market})
 			assert.Equal(t, hu.Mul1e6(big.NewInt(2840)), notionalPosition)
 			assert.Equal(t, hu.Mul1e6(big.NewInt(-740)), unrealizePnL)
 

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -74,7 +74,7 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	hState := &hu.HubbleState{
 		Assets:             pipeline.GetCollaterals(),
 		OraclePrices:       pipeline.GetUnderlyingPrices(),
-		LastPrices:         pipeline.GetMidPrices(),
+		MidPrices:          pipeline.GetMidPrices(),
 		ActiveMarkets:      markets,
 		MinAllowableMargin: pipeline.configService.getMinAllowableMargin(),
 		MaintenanceMargin:  pipeline.configService.getMaintenanceMargin(),

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -71,17 +71,23 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	}
 
 	// fetch the underlying price and run the matching engine
-	underlyingPrices := pipeline.GetUnderlyingPrices()
-	assets := pipeline.GetCollaterals()
+	hState := &hu.HubbleState{
+		Assets:             pipeline.GetCollaterals(),
+		OraclePrices:       pipeline.GetUnderlyingPrices(),
+		LastPrices:         pipeline.GetMidPrices(),
+		ActiveMarkets:      markets,
+		MinAllowableMargin: pipeline.configService.getMinAllowableMargin(),
+		MaintenanceMargin:  pipeline.configService.getMaintenanceMargin(),
+	}
 
 	// build trader map
-	liquidablePositions, ordersToCancel := pipeline.db.GetNaughtyTraders(underlyingPrices, assets, markets)
+	liquidablePositions, ordersToCancel := pipeline.db.GetNaughtyTraders(hState)
 	cancellableOrderIds := pipeline.cancelLimitOrders(ordersToCancel)
 	orderMap := make(map[Market]*Orders)
 	for _, market := range markets {
-		orderMap[market] = pipeline.fetchOrders(market, underlyingPrices[market], cancellableOrderIds, blockNumber)
+		orderMap[market] = pipeline.fetchOrders(market, hState.OraclePrices[market], cancellableOrderIds, blockNumber)
 	}
-	pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices)
+	pipeline.runLiquidations(liquidablePositions, orderMap, hState.OraclePrices)
 	for _, market := range markets {
 		// @todo should we prioritize matching in any particular market?
 		pipeline.runMatchingEngine(pipeline.lotp, orderMap[market].longOrders, orderMap[market].shortOrders)
@@ -117,6 +123,16 @@ func (pipeline *MatchingPipeline) GetUnderlyingPrices() map[Market]*big.Int {
 		underlyingPrices[Market(market)] = price
 	}
 	return underlyingPrices
+}
+
+func (pipeline *MatchingPipeline) GetMidPrices() map[Market]*big.Int {
+	prices := pipeline.configService.GetMidPrices()
+	log.Info("GetMidPrices", "prices", prices)
+	midPrices := make(map[Market]*big.Int)
+	for market, price := range prices {
+		midPrices[Market(market)] = price
+	}
+	return midPrices
 }
 
 func (pipeline *MatchingPipeline) GetCollaterals() []hu.Collateral {

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -231,7 +231,6 @@ type LimitOrderDatabase interface {
 	UpdateNextSamplePITime(nextSamplePITime uint64)
 	GetNextSamplePITime() uint64
 	UpdateLastPrice(market Market, lastPrice *big.Int)
-	GetLastPrice(market Market) *big.Int
 	GetLastPrices() map[Market]*big.Int
 	GetAllTraders() map[common.Address]Trader
 	GetOrderBookData() InMemoryDatabase
@@ -815,13 +814,6 @@ func (db *InMemoryDatabase) UpdateLastPremiumFraction(market Market, trader comm
 
 	db.TraderMap[trader].Positions[market].LastPremiumFraction = lastPremiumFraction
 	db.TraderMap[trader].Positions[market].UnrealisedFunding = hu.Div1e18(big.NewInt(0).Mul(big.NewInt(0).Sub(cumulativePremiumFraction, lastPremiumFraction), db.TraderMap[trader].Positions[market].Size))
-}
-
-func (db *InMemoryDatabase) GetLastPrice(market Market) *big.Int {
-	db.mu.RLock()
-	defer db.mu.RUnlock()
-
-	return big.NewInt(0).Set(db.LastPrice[market])
 }
 
 func (db *InMemoryDatabase) GetLastPrices() map[Market]*big.Int {

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -820,7 +820,11 @@ func (db *InMemoryDatabase) GetLastPrices() map[Market]*big.Int {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
-	return db.LastPrice
+	copyMap := make(map[Market]*big.Int)
+	for k, v := range db.LastPrice {
+		copyMap[k] = new(big.Int).Set(v)
+	}
+	return copyMap
 }
 
 func (db *InMemoryDatabase) GetAllTraders() map[common.Address]Trader {
@@ -920,7 +924,7 @@ func (db *InMemoryDatabase) GetNaughtyTraders(hState *hu.HubbleState) ([]Liquida
 			Positions:      translatePositions(trader.Positions),
 			Margins:        getMargins(trader, len(hState.Assets)),
 			PendingFunding: getTotalFunding(trader, hState.ActiveMarkets),
-			ReservedMargin: trader.Margin.Reserved,
+			ReservedMargin: new(big.Int).Set(trader.Margin.Reserved),
 		}
 		marginFraction := hu.GetMarginFraction(hState, userState)
 		if marginFraction.Cmp(hState.MaintenanceMargin) == -1 {

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -239,7 +239,7 @@ type LimitOrderDatabase interface {
 	Accept(acceptedBlockNumber uint64, blockTimestamp uint64)
 	SetOrderStatus(orderId common.Hash, status Status, info string, blockNumber uint64) error
 	RevertLastStatus(orderId common.Hash) error
-	GetNaughtyTraders(oraclePrices map[Market]*big.Int, assets []hu.Collateral, markets []Market) ([]LiquidablePosition, map[common.Address][]Order)
+	GetNaughtyTraders(hState *hu.HubbleState) ([]LiquidablePosition, map[common.Address][]Order)
 	GetAllOpenOrdersForTrader(trader common.Address) []Order
 	GetOpenOrdersForTraderByType(trader common.Address, orderType OrderType) []Order
 	UpdateLastPremiumFraction(market Market, trader common.Address, lastPremiumFraction *big.Int, cumlastPremiumFraction *big.Int)
@@ -912,7 +912,7 @@ func determinePositionToLiquidate(trader *Trader, addr common.Address, marginFra
 	return liquidable
 }
 
-func (db *InMemoryDatabase) GetNaughtyTraders(oraclePrices map[Market]*big.Int, assets []hu.Collateral, markets []Market) ([]LiquidablePosition, map[common.Address][]Order) {
+func (db *InMemoryDatabase) GetNaughtyTraders(hState *hu.HubbleState) ([]LiquidablePosition, map[common.Address][]Order) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
@@ -924,26 +924,30 @@ func (db *InMemoryDatabase) GetNaughtyTraders(oraclePrices map[Market]*big.Int, 
 	minSizes := []*big.Int{}
 
 	for addr, trader := range db.TraderMap {
-		pendingFunding := getTotalFunding(trader, markets)
-		marginFraction := calcMarginFraction(trader, pendingFunding, assets, oraclePrices, db.LastPrice, markets)
-		if marginFraction.Cmp(db.configService.getMaintenanceMargin()) == -1 {
+		userState := &hu.UserState{
+			Positions:      translatePositions(trader.Positions),
+			Margins:        getMargins(trader, len(hState.Assets)),
+			PendingFunding: getTotalFunding(trader, hState.ActiveMarkets),
+			ReservedMargin: trader.Margin.Reserved,
+		}
+		marginFraction := hu.GetMarginFraction(hState, userState)
+		if marginFraction.Cmp(hState.MaintenanceMargin) == -1 {
 			log.Info("below maintenanceMargin", "trader", addr.String(), "marginFraction", prettifyScaledBigInt(marginFraction, 6))
 			if len(minSizes) == 0 {
-				for _, market := range markets {
+				for _, market := range hState.ActiveMarkets {
 					minSizes = append(minSizes, db.configService.getMinSizeRequirement(market))
 				}
 			}
-			liquidablePositions = append(liquidablePositions, determinePositionToLiquidate(trader, addr, marginFraction, markets, minSizes))
+			liquidablePositions = append(liquidablePositions, determinePositionToLiquidate(trader, addr, marginFraction, hState.ActiveMarkets, minSizes))
 			continue // we do not check for their open orders yet. Maybe liquidating them first will make available margin positive
 		}
 		if trader.Margin.Reserved.Sign() == 0 {
 			continue
 		}
 		// has orders that might be cancellable
-		availableMargin := getAvailableMargin(trader, pendingFunding, assets, oraclePrices, db.LastPrice, db.configService.getMinAllowableMargin(), markets)
-		// availableMargin := getAvailableMarginWithDebugInfo(addr, trader, pendingFunding, oraclePrices, db.LastPrice, db.configService.getMinAllowableMargin(), markets)
+		availableMargin := hu.GetAvailableMargin(hState, userState)
 		if availableMargin.Sign() == -1 {
-			foundCancellableOrders := db.determineOrdersToCancel(addr, trader, availableMargin, oraclePrices, ordersToCancel)
+			foundCancellableOrders := db.determineOrdersToCancel(addr, trader, availableMargin, hState.OraclePrices, ordersToCancel)
 			if foundCancellableOrders {
 				log.Info("negative available margin", "trader", addr.String(), "availableMargin", prettifyScaledBigInt(availableMargin, 6))
 			} else {
@@ -1085,19 +1089,13 @@ func getBlankTrader() *Trader {
 	}
 }
 
-func getAvailableMargin(trader *Trader, pendingFunding *big.Int, assets []hu.Collateral, oraclePrices map[Market]*big.Int, lastPrices map[Market]*big.Int, minAllowableMargin *big.Int, markets []Market) *big.Int {
+func getAvailableMargin(trader *Trader, hState *hu.HubbleState) *big.Int {
 	return hu.GetAvailableMargin(
-		&hu.HubbleState{
-			Assets:             assets,
-			OraclePrices:       oraclePrices,
-			LastPrices:         lastPrices,
-			ActiveMarkets:      markets,
-			MinAllowableMargin: minAllowableMargin,
-		},
+		hState,
 		&hu.UserState{
 			Positions:      translatePositions(trader.Positions),
-			Margins:        getMargins(trader, len(assets)),
-			PendingFunding: pendingFunding,
+			Margins:        getMargins(trader, len(hState.Assets)),
+			PendingFunding: getTotalFunding(trader, hState.ActiveMarkets),
 			ReservedMargin: trader.Margin.Reserved,
 		},
 	)

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -428,7 +428,6 @@ func TestGetCancellableOrders(t *testing.T) {
 		MaintenanceMargin:  inMemoryDatabase.configService.getMaintenanceMargin(),
 	}
 	marginFraction := calcMarginFraction(_trader, hState)
-	// marginFraction := calcMarginFraction(_trader, big.NewInt(0), assets, priceMap, inMemoryDatabase.GetLastPrices(), []Market{market})
 	assert.Equal(t, new(big.Int).Div(hu.Mul1e6(depositMargin /* uPnL = 0 */), notionalPosition), marginFraction)
 
 	availableMargin := getAvailableMargin(_trader, hState)

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -422,7 +422,7 @@ func TestGetCancellableOrders(t *testing.T) {
 	hState := &hu.HubbleState{
 		Assets:             assets,
 		OraclePrices:       priceMap,
-		LastPrices:         inMemoryDatabase.GetLastPrices(),
+		MidPrices:          inMemoryDatabase.GetLastPrices(),
 		ActiveMarkets:      []Market{market},
 		MinAllowableMargin: inMemoryDatabase.configService.getMinAllowableMargin(),
 		MaintenanceMargin:  inMemoryDatabase.configService.getMaintenanceMargin(),
@@ -799,7 +799,7 @@ func TestGetLastPrice(t *testing.T) {
 	var market Market = 1
 	lastPrice := big.NewInt(20)
 	inMemoryDatabase.UpdateLastPrice(market, lastPrice)
-	assert.Equal(t, lastPrice, inMemoryDatabase.GetLastPrice(market))
+	assert.Equal(t, lastPrice, inMemoryDatabase.GetLastPrices()[market])
 }
 
 func TestUpdateReservedMargin(t *testing.T) {

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -116,7 +116,7 @@ func (db *MockLimitOrderDatabase) GetLastPrices() map[Market]*big.Int {
 	return map[Market]*big.Int{}
 }
 
-func (db *MockLimitOrderDatabase) GetNaughtyTraders(oraclePrices map[Market]*big.Int, assets []hu.Collateral, markets []Market) ([]LiquidablePosition, map[common.Address][]Order) {
+func (db *MockLimitOrderDatabase) GetNaughtyTraders(hState *hu.HubbleState) ([]LiquidablePosition, map[common.Address][]Order) {
 	return []LiquidablePosition{}, map[common.Address][]Order{}
 }
 
@@ -254,6 +254,10 @@ func (cs *MockConfigService) GetActiveMarketsCount() int64 {
 }
 
 func (cs *MockConfigService) GetUnderlyingPrices() []*big.Int {
+	return []*big.Int{}
+}
+
+func (cs *MockConfigService) GetMidPrices() []*big.Int {
 	return []*big.Int{}
 }
 

--- a/plugin/evm/orderbook/service.go
+++ b/plugin/evm/orderbook/service.go
@@ -112,8 +112,16 @@ func (api *OrderBookAPI) GetDebugData(ctx context.Context, trader string) GetDeb
 		pendingFunding := getTotalFunding(&trader, markets)
 		margin := new(big.Int).Sub(getNormalisedMargin(&trader, assets), pendingFunding)
 		notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(&trader, margin, hu.Min_Allowable_Margin, oraclePrices, lastPrices, markets)
-		marginFraction := calcMarginFraction(&trader, pendingFunding, assets, oraclePrices, lastPrices, markets)
-		availableMargin := getAvailableMargin(&trader, pendingFunding, assets, oraclePrices, lastPrices, api.configService.getMinAllowableMargin(), markets)
+		hState := &hu.HubbleState{
+			Assets:             assets,
+			OraclePrices:       oraclePrices,
+			LastPrices:         lastPrices,
+			ActiveMarkets:      markets,
+			MinAllowableMargin: api.configService.getMinAllowableMargin(),
+			MaintenanceMargin:  api.configService.getMaintenanceMargin(),
+		}
+		marginFraction := calcMarginFraction(&trader, hState)
+		availableMargin := getAvailableMargin(&trader, hState)
 		utilisedMargin := hu.Div1e6(new(big.Int).Mul(notionalPosition, minAllowableMargin))
 
 		response.MarginFraction[addr] = marginFraction

--- a/plugin/evm/orderbook/service.go
+++ b/plugin/evm/orderbook/service.go
@@ -73,6 +73,7 @@ type GetDebugDataResponse struct {
 	UnrealizePnL     map[common.Address]*big.Int
 	LastPrice        map[Market]*big.Int
 	OraclePrice      map[Market]*big.Int
+	MidPrice         map[Market]*big.Int
 }
 
 func (api *OrderBookAPI) GetDebugData(ctx context.Context, trader string) GetDebugDataResponse {
@@ -97,32 +98,34 @@ func (api *OrderBookAPI) GetDebugData(ctx context.Context, trader string) GetDeb
 		}
 	}
 
-	minAllowableMargin := api.configService.getMinAllowableMargin()
 	prices := api.configService.GetUnderlyingPrices()
-	lastPrices := api.db.GetLastPrices()
+	mPrices := api.configService.GetMidPrices()
+
 	oraclePrices := map[Market]*big.Int{}
+	midPrices := map[Market]*big.Int{}
 	count := api.configService.GetActiveMarketsCount()
 	markets := make([]Market, count)
 	for i := int64(0); i < count; i++ {
 		markets[i] = Market(i)
 		oraclePrices[Market(i)] = prices[Market(i)]
+		midPrices[Market(i)] = mPrices[Market(i)]
 	}
 	assets := api.configService.GetCollaterals()
 	for addr, trader := range traderMap {
 		pendingFunding := getTotalFunding(&trader, markets)
 		margin := new(big.Int).Sub(getNormalisedMargin(&trader, assets), pendingFunding)
-		notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(&trader, margin, hu.Min_Allowable_Margin, oraclePrices, lastPrices, markets)
+		notionalPosition, unrealizePnL := getTotalNotionalPositionAndUnrealizedPnl(&trader, margin, hu.Min_Allowable_Margin, oraclePrices, midPrices, markets)
 		hState := &hu.HubbleState{
 			Assets:             assets,
 			OraclePrices:       oraclePrices,
-			LastPrices:         lastPrices,
+			MidPrices:          midPrices,
 			ActiveMarkets:      markets,
 			MinAllowableMargin: api.configService.getMinAllowableMargin(),
 			MaintenanceMargin:  api.configService.getMaintenanceMargin(),
 		}
 		marginFraction := calcMarginFraction(&trader, hState)
 		availableMargin := getAvailableMargin(&trader, hState)
-		utilisedMargin := hu.Div1e6(new(big.Int).Mul(notionalPosition, minAllowableMargin))
+		utilisedMargin := hu.Div1e6(new(big.Int).Mul(notionalPosition, hState.MinAllowableMargin))
 
 		response.MarginFraction[addr] = marginFraction
 		response.AvailableMargin[addr] = availableMargin
@@ -134,8 +137,9 @@ func (api *OrderBookAPI) GetDebugData(ctx context.Context, trader string) GetDeb
 		response.ReservedMargin[addr] = trader.Margin.Reserved
 	}
 
-	response.LastPrice = lastPrices
+	response.LastPrice = api.db.GetLastPrices()
 	response.OraclePrice = oraclePrices
+	response.MidPrice = midPrices
 	return response
 }
 

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -184,8 +184,8 @@ func (api *TradingAPI) GetMarginAndPositions(ctx context.Context, trader string)
 	response.ReservedMargin = utils.BigIntToDecimal(traderInfo.Margin.Reserved, 6, 8)
 
 	for market, position := range traderInfo.Positions {
-		lastPrice := api.db.GetLastPrice(market)
-		notionalPosition, uPnL, mf := getPositionMetadata(lastPrice, position.OpenNotional, position.Size, margin)
+		midPrice := api.configService.GetMidPrices()[market]
+		notionalPosition, uPnL, mf := getPositionMetadata(midPrice, position.OpenNotional, position.Size, margin)
 
 		response.Positions = append(response.Positions, TraderPosition{
 			Market:               market,
@@ -197,7 +197,7 @@ func (api *TradingAPI) GetMarginAndPositions(ctx context.Context, trader string)
 			MarginFraction:       utils.BigIntToDecimal(mf, 6, 8),
 			NotionalPosition:     utils.BigIntToDecimal(notionalPosition, 6, 8),
 			LiquidationPrice:     "0", // todo: calculate
-			MarkPrice:            utils.BigIntToDecimal(lastPrice, 6, 8),
+			MarkPrice:            utils.BigIntToDecimal(midPrice, 6, 8),
 		})
 	}
 

--- a/precompile/contracts/bibliophile/clearing_house.go
+++ b/precompile/contracts/bibliophile/clearing_house.go
@@ -46,6 +46,8 @@ func GetMarkets(stateDB contract.StateDB) []common.Address {
 	numMarkets := GetActiveMarketsCount(stateDB)
 	markets := make([]common.Address, numMarkets)
 	baseStorageSlot := marketsStorageSlot()
+	// @todo when we ever settle a market, here it needs to be taken care of
+	// because currently the following assumes that all markets are active
 	for i := int64(0); i < numMarkets; i++ {
 		amm := stateDB.GetState(common.HexToAddress(CLEARING_HOUSE_GENESIS_ADDRESS), common.BigToHash(new(big.Int).Add(baseStorageSlot, big.NewInt(i))))
 		markets[i] = common.BytesToAddress(amm.Bytes())
@@ -69,13 +71,13 @@ func getNotionalPositionAndMargin(stateDB contract.StateDB, input *GetNotionalPo
 	numMarkets := len(markets)
 	positions := make(map[int]*hu.Position, numMarkets)
 	underlyingPrices := make(map[int]*big.Int, numMarkets)
-	lastPrices := make(map[int]*big.Int, numMarkets)
-	var marketIds []int
+	midPrices := make(map[int]*big.Int, numMarkets)
+	var activeMarketIds []int
 	for i, market := range markets {
 		positions[i] = getPosition(stateDB, getMarketAddressFromMarketID(int64(i), stateDB), &input.Trader)
 		underlyingPrices[i] = getUnderlyingPrice(stateDB, market)
-		lastPrices[i] = getLastPrice(stateDB, market)
-		marketIds = append(marketIds, i)
+		midPrices[i] = getMidPrice(stateDB, market)
+		activeMarketIds = append(activeMarketIds, i)
 	}
 	pendingFunding := big.NewInt(0)
 	if input.IncludeFundingPayments {
@@ -85,8 +87,8 @@ func getNotionalPositionAndMargin(stateDB contract.StateDB, input *GetNotionalPo
 		&hu.HubbleState{
 			Assets:        GetCollaterals(stateDB),
 			OraclePrices:  underlyingPrices,
-			LastPrices:    lastPrices,
-			ActiveMarkets: marketIds,
+			LastPrices:    midPrices,
+			ActiveMarkets: activeMarketIds,
 		},
 		&hu.UserState{
 			Positions:      positions,

--- a/precompile/contracts/bibliophile/clearing_house.go
+++ b/precompile/contracts/bibliophile/clearing_house.go
@@ -132,6 +132,14 @@ func GetUnderlyingPrices(stateDB contract.StateDB) []*big.Int {
 	return underlyingPrices
 }
 
+func GetMidPrices(stateDB contract.StateDB) []*big.Int {
+	underlyingPrices := make([]*big.Int, 0)
+	for _, market := range GetMarkets(stateDB) {
+		underlyingPrices = append(underlyingPrices, getMidPrice(stateDB, market))
+	}
+	return underlyingPrices
+}
+
 func getPosSizes(stateDB contract.StateDB, trader *common.Address) []*big.Int {
 	positionSizes := make([]*big.Int, 0)
 	for _, market := range GetMarkets(stateDB) {

--- a/precompile/contracts/bibliophile/clearing_house.go
+++ b/precompile/contracts/bibliophile/clearing_house.go
@@ -87,7 +87,7 @@ func getNotionalPositionAndMargin(stateDB contract.StateDB, input *GetNotionalPo
 		&hu.HubbleState{
 			Assets:        GetCollaterals(stateDB),
 			OraclePrices:  underlyingPrices,
-			LastPrices:    midPrices,
+			MidPrices:     midPrices,
 			ActiveMarkets: activeMarketIds,
 		},
 		&hu.UserState{


### PR DESCRIPTION
## Why this should be merged
- Use mid price instead of last price for determining pnl. Corresponding contracts [PR](https://github.com/hubble-exchange/hubble-protocol/pull/205).