### PR TITLE
send order hash during failed match validations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,10 @@ COPY . .
 ARG SUBNET_EVM_COMMIT
 ARG CURRENT_BRANCH
 
-RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && export CURRENT_BRANCH=$CURRENT_BRANCH && ./scripts/build.sh /build/o1Fg94YukvVRijwyThAavybVfwVJH3dhyz94g6qYRGdQ5Arqp
+RUN export SUBNET_EVM_COMMIT=$SUBNET_EVM_COMMIT && export CURRENT_BRANCH=$CURRENT_BRANCH && ./scripts/build.sh /build/jvrKsTB9MfYGnAXtxbzFYpXKceXr9J8J8ej6uWGrYM5tXswhJ
 
 # ============= Cleanup Stage ================
 FROM avaplatform/avalanchego:$AVALANCHE_VERSION AS builtImage
 
 # Copy the evm binary into the correct location in the container
-COPY --from=builder /build/o1Fg94YukvVRijwyThAavybVfwVJH3dhyz94g6qYRGdQ5Arqp /avalanchego/build/plugins/o1Fg94YukvVRijwyThAavybVfwVJH3dhyz94g6qYRGdQ5Arqp
+COPY --from=builder /build/jvrKsTB9MfYGnAXtxbzFYpXKceXr9J8J8ej6uWGrYM5tXswhJ /avalanchego/build/plugins/jvrKsTB9MfYGnAXtxbzFYpXKceXr9J8J8ej6uWGrYM5tXswhJ

--- a/genesis.json
+++ b/genesis.json
@@ -22,6 +22,10 @@
         "maxBlockGasCost": 5000000,
         "blockGasCostStep": 10000
       },
+      "contractNativeMinterConfig": {
+        "blockTimestamp": 0,
+        "adminAddresses": ["0x70997970C51812dc3A010C7d01b50e0d17dc79C8","0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC"]
+      },
       "contractDeployerAllowListConfig": {
         "blockTimestamp": 0,
         "adminAddresses": ["0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC","0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266"]

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -156,7 +156,7 @@ func (cep *ContractEventsProcessor) handleOrderBookEvent(event *types.Log) {
 		}
 		orderId := event.Topics[1]
 		if !removed {
-			log.Info("OrderMatchingError", "args", args, "orderId", orderId.String(), "number", event.BlockNumber)
+			log.Info("OrderMatchingError", "args", args, "orderId", orderId.String(), "TxHash", event.TxHash, "number", event.BlockNumber)
 			if err := cep.database.SetOrderStatus(orderId, Execution_Failed, args["err"].(string), event.BlockNumber); err != nil {
 				log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
 				return

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -45,6 +45,7 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	// reset ticker
 	pipeline.MatchingTicker.Reset(matchingTickerDuration)
 	markets := pipeline.GetActiveMarkets()
+	log.Info("MatchingPipeline:Run", "blockNumber", blockNumber)
 
 	if len(markets) == 0 {
 		return false

--- a/precompile/contracts/juror/matching_validation_test.go
+++ b/precompile/contracts/juror/matching_validation_test.go
@@ -243,6 +243,18 @@ func TestValidateExecuteLimitOrder(t *testing.T) {
 			OrderHash:         orderHash,
 		}, m)
 	})
+
+	t.Run("validateExecuteLimitOrder returns orderHash even when validation fails", func(t *testing.T) {
+		orderHash, err := order.Hash()
+		assert.Nil(t, err)
+
+		mockBibliophile.EXPECT().GetOrderFilledAmount(orderHash).Return(filledAmount).Times(1)
+		mockBibliophile.EXPECT().GetOrderStatus(orderHash).Return(int64(2)).Times(1) // Filled
+
+		m, err := validateExecuteLimitOrder(mockBibliophile, order, Long, fillAmount)
+		assert.EqualError(t, err, ErrInvalidOrder.Error())
+		assert.Equal(t, orderHash, m.OrderHash)
+	})
 }
 
 func assertMetadataEquality(t *testing.T, expected, actual *Metadata) {

--- a/precompile/contracts/juror/matching_validation_test.go
+++ b/precompile/contracts/juror/matching_validation_test.go
@@ -232,7 +232,7 @@ func TestValidateExecuteLimitOrder(t *testing.T) {
 		mockBibliophile.EXPECT().GetBlockPlaced(orderHash).Return(blockPlaced).Times(1)                              // placed
 		mockBibliophile.EXPECT().GetMarketAddressFromMarketID(order.AmmIndex.Int64()).Return(marketAddress).Times(1) // placed
 
-		m, err := validateExecuteLimitOrder(mockBibliophile, order, Long, fillAmount, orderHash)
+		m, err := validateExecuteLimitOrder(mockBibliophile, order, Long, fillAmount)
 		assert.Nil(t, err)
 		assertMetadataEquality(t, &Metadata{
 			AmmIndex:          new(big.Int).Set(order.AmmIndex),


### PR DESCRIPTION
So that the reason can be printed in EVM and OrderMatchingError can be searched by indexed field `orderHash`