### PR TITLE
Sorted order arrays snapshot fix

### DIFF
--- a/network-configs/aylin/chain_api_node.json
+++ b/network-configs/aylin/chain_api_node.json
@@ -8,5 +8,6 @@
     "priority-regossip-addresses": ["0x06CCAD927e6B1d36E219Cb582Af3185D0705f78F"],
     "coreth-admin-api-enabled": true,
     "eth-apis": ["public-eth","public-eth-filter","net","web3","internal-public-eth","internal-public-blockchain","internal-public-transaction-pool","internal-public-debug","internal-private-debug","internal-public-tx-pool","internal-public-account","debug-tracer"],
-    "trading-api-enabled": true
+    "trading-api-enabled": true,
+    "testing-api-enabled": true
 }

--- a/network-configs/aylin/chain_archival_node.json
+++ b/network-configs/aylin/chain_archival_node.json
@@ -9,5 +9,6 @@
     "priority-regossip-addresses": ["0x06CCAD927e6B1d36E219Cb582Af3185D0705f78F"],
     "coreth-admin-api-enabled": true,
     "eth-apis": ["public-eth","public-eth-filter","net","web3","internal-public-eth","internal-public-blockchain","internal-public-transaction-pool","internal-public-debug","internal-private-debug","internal-public-tx-pool","internal-public-account","debug-tracer"],
-    "trading-api-enabled": true
+    "trading-api-enabled": true,
+    "testing-api-enabled": true
 }

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -383,6 +383,9 @@ func (lop *limitOrderProcesser) saveMemoryDBSnapshot(acceptedBlockNumber *big.In
 		cev.ProcessEvents(logsToRemove)
 	}
 
+	// these SHOULD be re-populated while loading from snapshot
+	memoryDBCopy.LongOrders = nil
+	memoryDBCopy.ShortOrders = nil
 	snapshot := orderbook.Snapshot{
 		Data:                memoryDBCopy,
 		AcceptedBlockNumber: acceptedBlockNumber,

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -63,7 +63,7 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	}
 
 	// check nextSamplePITime
-	if isSamplePITime(pipeline.db.GetNextSamplePITime()) {
+	if isSamplePITime(pipeline.db.GetNextSamplePITime(), pipeline.db.GetSamplePIAttemptedTime()) {
 		log.Info("MatchingPipeline:isSamplePITime")
 		err := pipeline.lotp.ExecuteSamplePITx()
 		if err != nil {
@@ -328,13 +328,13 @@ func isFundingPaymentTime(nextFundingTime uint64) bool {
 	return now >= nextFundingTime
 }
 
-func isSamplePITime(nextSamplePITime uint64) bool {
+func isSamplePITime(nextSamplePITime, lastAttempt uint64) bool {
 	if nextSamplePITime == 0 {
 		return false
 	}
 
 	now := uint64(time.Now().Unix())
-	return now >= nextSamplePITime
+	return now >= nextSamplePITime && now >= lastAttempt+5 // give 5 secs for the tx to be mined
 }
 
 func executeFundingPayment(lotp LimitOrderTxProcessor) error {

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -151,6 +151,12 @@ func (db *MockLimitOrderDatabase) GetTraderInfo(trader common.Address) *Trader {
 	return &Trader{}
 }
 
+func (db *MockLimitOrderDatabase) GetSamplePIAttemptedTime() uint64 {
+	return 0
+}
+
+func (db *MockLimitOrderDatabase) SignalSamplePIAttempted(time uint64) {}
+
 type MockLimitOrderTxProcessor struct {
 	mock.Mock
 }

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -120,7 +120,7 @@ func (lotp *limitOrderTxProcessor) ExecuteFundingPaymentTx() error {
 func (lotp *limitOrderTxProcessor) ExecuteSamplePITx() error {
 	txHash, err := lotp.executeLocalTx(lotp.clearingHouseContractAddress, lotp.clearingHouseABI, "samplePI")
 	log.Info("ExecuteSamplePITx", "txHash", txHash.String(), "err", err)
-	if err != nil {
+	if err == nil {
 		lotp.memoryDb.SignalSamplePIAttempted(uint64(time.Now().Unix()))
 	}
 	return err

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -3,6 +3,7 @@ package orderbook
 import (
 	"context"
 	"crypto/ecdsa"
+	"time"
 
 	// "encoding/hex"
 	"errors"
@@ -119,6 +120,9 @@ func (lotp *limitOrderTxProcessor) ExecuteFundingPaymentTx() error {
 func (lotp *limitOrderTxProcessor) ExecuteSamplePITx() error {
 	txHash, err := lotp.executeLocalTx(lotp.clearingHouseContractAddress, lotp.clearingHouseABI, "samplePI")
 	log.Info("ExecuteSamplePITx", "txHash", txHash.String(), "err", err)
+	if err != nil {
+		lotp.memoryDb.SignalSamplePIAttempted(uint64(time.Now().Unix()))
+	}
 	return err
 }
 


### PR DESCRIPTION
## Why this should be merged
- Don't load sorted Long and Short order arrays
- Wait 5 secs before attempting premium index snapshot again, otherwise we end of creating 2 txs every time
- Enable testing-api in API nodes