### PR TITLE
update optimalPnl algorithm

### DIFF
--- a/plugin/evm/orderbook/hubbleutils/margin_math_test.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math_test.go
@@ -8,25 +8,62 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var hState = &HubbleState{
+	Assets: []Collateral{
+		{
+			Price:    big.NewInt(1.01 * 1e6), // 1.01
+			Weight:   big.NewInt(1e6),        // 1
+			Decimals: 6,
+		},
+		{
+			Price:    big.NewInt(54.36 * 1e6), // 54.36
+			Weight:   big.NewInt(0.7 * 1e6),   // 0.7
+			Decimals: 6,
+		},
+	},
+	MidPrices: map[Market]*big.Int{
+		0: big.NewInt(1544.21 * 1e6), // 1544.21
+		1: big.NewInt(19.5 * 1e6),    // 19.5
+	},
+	OraclePrices: map[Market]*big.Int{
+		0: big.NewInt(1503.21 * 1e6),
+		1: big.NewInt(17.5 * 1e6),
+	},
+	ActiveMarkets: []Market{
+		0, 1,
+	},
+	MinAllowableMargin: big.NewInt(100000), // 0.1
+	MaintenanceMargin:  big.NewInt(200000), // 0.2
+}
+
+var userState = &UserState{
+	Positions: map[Market]*Position{
+		0: {
+			Size:         big.NewInt(0.582 * 1e18), // 0.0582
+			OpenNotional: big.NewInt(875 * 1e6),  // 87.5, openPrice = 1503.43
+		},
+		1: {
+			Size:         Scale(big.NewInt(-101), 18), // -101
+			OpenNotional: big.NewInt(1767.5 * 1e6),    // 1767.5, openPrice = 17.5
+		},
+	},
+	Margins: []*big.Int{
+		big.NewInt(30.5 * 1e6), // 30.5
+		big.NewInt(14 * 1e6),   // 14
+	},
+	PendingFunding: big.NewInt(0),
+	ReservedMargin: big.NewInt(0),
+}
+
 func TestWeightedAndSpotCollateral(t *testing.T) {
-	assets := []Collateral{
-		{
-			Price:    big.NewInt(80500000), // 80.5
-			Weight:   big.NewInt(800000),   // 0.8
-			Decimals: 6,
-		},
-		{
-			Price:    big.NewInt(410000), // 0.41
-			Weight:   big.NewInt(900000), // 0.9
-			Decimals: 6,
-		},
-	}
-	margins := []*big.Int{
-		big.NewInt(3500000),    // 3.5
-		big.NewInt(1040000000), // 1040
-	}
-	expectedWeighted := big.NewInt(609160000) // 609.16
-	expectedSpot := big.NewInt(708150000)     // 708.15
+	assets := hState.Assets
+	margins := userState.Margins
+	expectedWeighted := Unscale(Mul(Mul(margins[0], assets[0].Price), assets[0].Weight), assets[0].Decimals+6)
+	expectedWeighted.Add(expectedWeighted, Unscale(Mul(Mul(margins[1], assets[1].Price), assets[1].Weight), assets[1].Decimals+6))
+
+	expectedSpot := Unscale(Mul(margins[0], assets[0].Price), assets[0].Decimals)
+	expectedSpot.Add(expectedSpot, Unscale(Mul(margins[1], assets[1].Price), assets[1].Decimals))
+
 	resultWeighted, resultSpot := WeightedAndSpotCollateral(assets, margins)
 	fmt.Println(resultWeighted, resultSpot)
 	assert.Equal(t, expectedWeighted, resultWeighted)
@@ -79,43 +116,17 @@ func TestGetPositionMetadata(t *testing.T) {
 }
 
 func TestGetOptimalPnl(t *testing.T) {
-	hState := &HubbleState{
-		Assets: []Collateral{
-			{
-				Price:    big.NewInt(101000000), // 101
-				Weight:   big.NewInt(900000),    // 0.9
-				Decimals: 6,
-			},
-			{
-				Price:    big.NewInt(54360000), // 54.36
-				Weight:   big.NewInt(700000),   // 0.7
-				Decimals: 6,
-			},
-		},
-		MidPrices: map[Market]*big.Int{
-			0: big.NewInt(1545340000), // 1545.34
-		},
-		OraclePrices: map[Market]*big.Int{
-			0: big.NewInt(1545210000), // 1545.21
-		},
-		ActiveMarkets: []Market{
-			0,
-		},
-		MinAllowableMargin: big.NewInt(100000), // 0.1
-		MaintenanceMargin:  big.NewInt(200000), // 0.2
-	}
-	position := &Position{
-		Size:         Scale(big.NewInt(582), 14), // 0.0582
-		OpenNotional: big.NewInt(87500000),       // 87.5
-	}
-	margin := big.NewInt(20000000) // 20
+	margin := big.NewInt(20 * 1e6) // 20
 	market := 0
+	position := userState.Positions[market]
 	marginMode := Maintenance_Margin
 
 	notionalPosition, uPnL := GetOptimalPnl(hState, position, margin, market, marginMode)
 
-	expectedNotionalPosition := big.NewInt(89938788)
-	expectedUPnL := big.NewInt(2438788)
+	// mid price pnl is more than oracle price pnl
+	expectedNotionalPosition := Unscale(Mul(position.Size, hState.MidPrices[market]), 18)
+	expectedUPnL := Sub(expectedNotionalPosition, position.OpenNotional)
+	fmt.Println("Maintenace_Margin_Mode", "notionalPosition", notionalPosition, "uPnL", uPnL)
 
 	assert.Equal(t, expectedNotionalPosition, notionalPosition)
 	assert.Equal(t, expectedUPnL, uPnL)
@@ -123,11 +134,87 @@ func TestGetOptimalPnl(t *testing.T) {
 	// ------ when marginMode is Min_Allowable_Margin ------
 
 	marginMode = Min_Allowable_Margin
-
 	notionalPosition, uPnL = GetOptimalPnl(hState, position, margin, market, marginMode)
 
-	expectedNotionalPosition = big.NewInt(89931222)
-	expectedUPnL = big.NewInt(2431222)
+	expectedNotionalPosition = Unscale(Mul(position.Size, hState.OraclePrices[market]), 18)
+	expectedUPnL = Sub(expectedNotionalPosition, position.OpenNotional)
+	fmt.Println("Min_Allowable_Margin_Mode", "notionalPosition", notionalPosition, "uPnL", uPnL)
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUPnL, uPnL)
+}
+
+func TestGetOptimalPnlDeprecated(t *testing.T) {
+	margin := big.NewInt(20 * 1e6) // 20
+	market := 0
+	position := userState.Positions[market]
+	marginMode := Maintenance_Margin
+
+	notionalPosition, uPnL := GetOptimalPnlDeprecated(hState, position, margin, market, marginMode)
+
+	// mid price pnl is more than oracle price pnl
+	expectedNotionalPosition := Unscale(Mul(position.Size, hState.MidPrices[market]), 18)
+	expectedUPnL := Sub(expectedNotionalPosition, position.OpenNotional)
+	fmt.Println("Maintenace_Margin_Mode", "notionalPosition", notionalPosition, "uPnL", uPnL)
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUPnL, uPnL)
+
+	// ------ when marginMode is Min_Allowable_Margin ------
+
+	marginMode = Min_Allowable_Margin
+	notionalPosition, uPnL = GetOptimalPnlDeprecated(hState, position, margin, market, marginMode)
+
+	expectedNotionalPosition = Unscale(Mul(position.Size, hState.OraclePrices[market]), 18)
+	expectedUPnL = Sub(expectedNotionalPosition, position.OpenNotional)
+	fmt.Println("Min_Allowable_Margin_Mode", "notionalPosition", notionalPosition, "uPnL", uPnL)
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUPnL, uPnL)
+}
+
+func TestGetTotalNotionalPositionAndUnrealizedPnl(t *testing.T) {
+	margin := GetNormalizedMargin(hState.Assets, userState.Margins)
+	// margin := big.NewInt(2000 * 1e6) // 50
+	fmt.Println("margin = ", margin) // 563.533
+	marginMode := Maintenance_Margin
+	fmt.Println("availableMargin = ", GetAvailableMargin(hState, userState))
+	fmt.Println("marginFraction = ", GetMarginFraction(hState, userState))
+
+	notionalPosition, uPnL := GetTotalNotionalPositionAndUnrealizedPnl(hState, userState, margin, marginMode)
+	fmt.Println("Maintenace_Margin_Mode ", "notionalPosition = ", notionalPosition, "uPnL = ", uPnL)
+	_, pnl := GetOptimalPnl(hState, userState.Positions[0], margin, 0, marginMode)
+	fmt.Println("best pnl market 0 =", pnl)
+	_, pnl = GetOptimalPnl(hState, userState.Positions[1], margin, 1, marginMode)
+	fmt.Println("best pnl market 1 =", pnl)
+
+	// mid price pnl is more than oracle price pnl for long position
+	expectedNotionalPosition := Unscale(Mul(userState.Positions[0].Size, hState.MidPrices[0]), 18)
+	expectedUPnL := Sub(expectedNotionalPosition, userState.Positions[0].OpenNotional)
+	// oracle price pnl is more than mid price pnl for short position
+	expectedNotional2 := Abs(Unscale(Mul(userState.Positions[1].Size, hState.OraclePrices[1]), 18))
+	expectedNotionalPosition.Add(expectedNotionalPosition, expectedNotional2)
+	expectedUPnL.Add(expectedUPnL, Sub(userState.Positions[1].OpenNotional, expectedNotional2))
+
+	assert.Equal(t, expectedNotionalPosition, notionalPosition)
+	assert.Equal(t, expectedUPnL, uPnL)
+
+	// ------ when marginMode is Min_Allowable_Margin ------
+
+	marginMode = Min_Allowable_Margin
+	notionalPosition, uPnL = GetTotalNotionalPositionAndUnrealizedPnl(hState, userState, margin, marginMode)
+	fmt.Println("Min_Allowable_Margin_Mode ", "notionalPosition = ", notionalPosition, "uPnL = ", uPnL)
+
+	_, pnl = GetOptimalPnl(hState, userState.Positions[0], margin, 0, marginMode)
+	fmt.Println("worst pnl market 0 =", pnl)
+	_, pnl = GetOptimalPnl(hState, userState.Positions[1], margin, 1, marginMode)
+	fmt.Println("worst pnl market 1 =", pnl)
+
+	expectedNotionalPosition = Unscale(Mul(userState.Positions[0].Size, hState.OraclePrices[0]), 18)
+	expectedUPnL = Sub(expectedNotionalPosition, userState.Positions[0].OpenNotional)
+	expectedNotional2 = Abs(Unscale(Mul(userState.Positions[1].Size, hState.MidPrices[1]), 18))
+	expectedNotionalPosition.Add(expectedNotionalPosition, expectedNotional2)
+	expectedUPnL.Add(expectedUPnL, Sub(userState.Positions[1].OpenNotional, expectedNotional2))
 
 	assert.Equal(t, expectedNotionalPosition, notionalPosition)
 	assert.Equal(t, expectedUPnL, uPnL)


### PR DESCRIPTION
## Why this should be merged
This fixes an anomaly in calculating the optimal pnl formula which returns lower pnl in best case and higher pnl in worst case when `margin > openNotional` for long and `margin < -openNotional` for shorts. 
This can lead to false liquidation scenarios if the above conditions are matched.
```
marginFraction = margin + unrealizedPnl / notional
notional = | price * size |

## long
unrealizedPnl = price * size - openNotional

## assumption
If, mf1 > mf2, then unrealizedPnl1 > unrealizedPnl2

P1 * size - openNotional > P2 * size - openNotional
=> P1 > P2 --- (1)

mf1 > mf2
=> (M + P1 * size - openNotional) / P1 * size > (M + P2 * size - openNotional) / P2 * size
=> (M - openNotional) * P2 > (M - openNotional) * P1
=> (openNotional - M) * P1 > (openNotional - M) * P2 --- (2)
```
## How this works
Compares unrealized pnl directly instead of margin fraction comparison
## How this was tested

## How is this documented
