### PR TITLE
Check margin requirement for IOC orders in matching

### DIFF
--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -462,6 +462,7 @@ func executeFuncAndRecoverPanic(fn func(), panicMessage string, panicCounter met
 
 			log.Error(panicMessage, "errorMessage", errorMessage, "stack_trace", string(debug.Stack()))
 			panicCounter.Inc(1)
+			orderbook.AllPanicsCounter.Inc(1)
 		}
 	}()
 	fn()

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -105,5 +105,6 @@ func (cs *ConfigService) GetCumulativePremiumFraction(market Market) *big.Int {
 }
 
 func (cs *ConfigService) GetTakerFee() *big.Int {
-	return bibliophile.GetTakerFee(cs.getStateAtCurrentBlock())
+	takerFee := bibliophile.GetTakerFee(cs.getStateAtCurrentBlock())
+	return hu.Div(hu.Mul(takerFee, big.NewInt(8)), big.NewInt(10)) // 20% discount, which is applied to everyone currently
 }

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -24,6 +24,7 @@ type IConfigService interface {
 	GetCumulativePremiumFraction(market Market) *big.Int
 	GetAcceptableBounds(market Market) (*big.Int, *big.Int)
 	GetAcceptableBoundsForLiquidation(market Market) (*big.Int, *big.Int)
+	GetTakerFee() *big.Int
 }
 
 type ConfigService struct {
@@ -101,4 +102,8 @@ func (cs *ConfigService) GetLastPremiumFraction(market Market, trader *common.Ad
 func (cs *ConfigService) GetCumulativePremiumFraction(market Market) *big.Int {
 	markets := bibliophile.GetMarkets(cs.getStateAtCurrentBlock())
 	return bibliophile.GetCumulativePremiumFraction(cs.getStateAtCurrentBlock(), markets[market])
+}
+
+func (cs *ConfigService) GetTakerFee() *big.Int {
+	return bibliophile.GetTakerFee(cs.getStateAtCurrentBlock())
 }

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -728,6 +728,8 @@ func (cep *ContractEventsProcessor) updateMetrics(logs []*types.Log) {
 				ordertype := order.OrderType
 				metricName := fmt.Sprintf("%s/%s/%s/%s", "events", "OrderMatchingError", ordertype, utils.RemoveSpacesAndSpecialChars(errorString))
 				metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
+			} else {
+				log.Error("updateMetrics - error in getting order", "event", "OrderMatchingError")
 			}
 		}
 	}

--- a/plugin/evm/orderbook/contract_events_processor.go
+++ b/plugin/evm/orderbook/contract_events_processor.go
@@ -155,9 +155,10 @@ func (cep *ContractEventsProcessor) handleOrderBookEvent(event *types.Log) {
 			return
 		}
 		orderId := event.Topics[1]
+		errorString := args["err"].(string)
 		if !removed {
 			log.Info("OrderMatchingError", "args", args, "orderId", orderId.String(), "TxHash", event.TxHash, "number", event.BlockNumber)
-			if err := cep.database.SetOrderStatus(orderId, Execution_Failed, args["err"].(string), event.BlockNumber); err != nil {
+			if err := cep.database.SetOrderStatus(orderId, Execution_Failed, errorString, event.BlockNumber); err != nil {
 				log.Error("error in SetOrderStatus", "method", "OrderMatchingError", "err", err)
 				return
 			}
@@ -704,17 +705,30 @@ func (cep *ContractEventsProcessor) updateMetrics(logs []*types.Log) {
 
 		metricName := fmt.Sprintf("%s/%s", "events", event_.Name)
 
-		if !event.Removed {
-			metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
-		} else {
-			metrics.GetOrRegisterCounter(metricName, nil).Dec(1)
-		}
+		metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
 
 		switch event_.Name {
 		case "OrderAccepted":
-			orderAcceptedCount++
+			orderAcceptedCount += 1
 		case "OrderCancelAccepted":
-			orderCancelledCount++
+			orderCancelledCount += 1
+		case "OrderMatchingError":
+			// separate metrics for combination of order type and error string - for more granular analysis
+			args := map[string]interface{}{}
+			err := cep.orderBookABI.UnpackIntoMap(args, "OrderMatchingError", event.Data)
+			if err != nil {
+				log.Error("error in orderBookAbi.UnpackIntoMap", "method", "OrderMatchingError", "err", err)
+				return
+			}
+			orderId := event.Topics[1]
+			errorString := args["err"].(string)
+
+			order := cep.database.GetOrderById(orderId)
+			if order != nil {
+				ordertype := order.OrderType
+				metricName := fmt.Sprintf("%s/%s/%s/%s", "events", "OrderMatchingError", ordertype, utils.RemoveSpacesAndSpecialChars(errorString))
+				metrics.GetOrRegisterCounter(metricName, nil).Inc(1)
+			}
 		}
 	}
 

--- a/plugin/evm/orderbook/hubbleutils/margin_math.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math.go
@@ -12,6 +12,7 @@ type HubbleState struct {
 	ActiveMarkets      []Market
 	MinAllowableMargin *big.Int
 	MaintenanceMargin  *big.Int
+	TakerFee           *big.Int
 }
 
 type UserState struct {

--- a/plugin/evm/orderbook/liquidations_test.go
+++ b/plugin/evm/orderbook/liquidations_test.go
@@ -20,7 +20,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			OraclePrices:  map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))},
 			ActiveMarkets: []hu.Market{market},
 		}
-		liquidablePositions, _ := db.GetNaughtyTraders(hState)
+		liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 		assert.Equal(t, 0, len(liquidablePositions))
 	})
 
@@ -44,7 +44,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			ActiveMarkets:     []hu.Market{market},
 			MaintenanceMargin: db.configService.getMaintenanceMargin(),
 		}
-		liquidablePositions, _ := db.GetNaughtyTraders(hState)
+		liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 		assert.Equal(t, 0, len(liquidablePositions))
 	})
 
@@ -109,7 +109,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginLong, pendingFundingLong), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(hState)
+			liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 
@@ -165,7 +165,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginLong, pendingFundingLong), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(hState)
+			liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 	})
@@ -228,7 +228,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginShort, pendingFundingShort), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(hState)
+			liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 
@@ -283,7 +283,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			marginFraction := calcMarginFraction(_trader, hState)
 			assert.Equal(t, new(big.Int).Div(hu.Mul1e6(new(big.Int).Add(new(big.Int).Sub(marginShort, pendingFundingShort), unrealizePnL)), notionalPosition), marginFraction)
 
-			liquidablePositions, _ := db.GetNaughtyTraders(hState)
+			liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 			assert.Equal(t, 0, len(liquidablePositions))
 		})
 	})

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -285,6 +285,10 @@ func (pipeline *MatchingPipeline) filterEligibleOrders(orders *Orders, hState *h
 	// inner function for filtering
 	hasSufficientMargin := func(order Order) bool {
 		trader := pipeline.db.GetTraderInfo(order.Trader)
+		if trader == nil {
+			// no trader related activity, not even margin deposit. Should never happen ideally
+			return false
+		}
 		userState := hu.UserState{
 			Positions:      translatePositions(trader.Positions),
 			Margins:        getMargins(trader, len(hState.Assets)),

--- a/plugin/evm/orderbook/matching_pipeline_test.go
+++ b/plugin/evm/orderbook/matching_pipeline_test.go
@@ -25,7 +25,7 @@ func TestRunLiquidations(t *testing.T) {
 		shortOrders := []Order{getShortOrder()}
 
 		orderMap := map[Market]*Orders{market: {longOrders, shortOrders}}
-		pipeline.runLiquidations([]LiquidablePosition{}, orderMap, underlyingPrices)
+		pipeline.runLiquidations([]LiquidablePosition{}, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 		assert.Equal(t, longOrders, orderMap[market].longOrders)
 		assert.Equal(t, shortOrders, orderMap[market].shortOrders)
 		lotp.AssertNotCalled(t, "ExecuteLiquidation", mock.Anything, mock.Anything, mock.Anything)
@@ -40,7 +40,9 @@ func TestRunLiquidations(t *testing.T) {
 			orderMap := map[Market]*Orders{market: {longOrders, shortOrders}}
 
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			pipeline.runLiquidations([]LiquidablePosition{getLiquidablePos(traderAddress, LONG, 7)}, orderMap, underlyingPrices)
+			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetTakerFee").Return(big.NewInt(1e5))
+			pipeline.runLiquidations([]LiquidablePosition{getLiquidablePos(traderAddress, LONG, 7)}, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 			assert.Equal(t, longOrders, orderMap[market].longOrders)
 			assert.Equal(t, shortOrders, orderMap[market].shortOrders)
 			lotp.AssertNotCalled(t, "ExecuteLiquidation", mock.Anything, mock.Anything, mock.Anything)
@@ -53,11 +55,13 @@ func TestRunLiquidations(t *testing.T) {
 			shortOrder := getShortOrder()
 			expectedFillAmount := utils.BigIntMinAbs(longOrder.BaseAssetQuantity, liquidablePositions[0].Size)
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
+			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			lotp.On("ExecuteLiquidation", traderAddress, longOrder, expectedFillAmount).Return(nil)
 
 			orderMap := map[Market]*Orders{market: {[]Order{longOrder}, []Order{shortOrder}}}
 
-			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices)
+			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 
 			lotp.AssertCalled(t, "ExecuteLiquidation", traderAddress, longOrder, expectedFillAmount)
 			cs.AssertCalled(t, "GetAcceptableBoundsForLiquidation", market)
@@ -75,11 +79,13 @@ func TestRunLiquidations(t *testing.T) {
 
 			expectedFillAmount := utils.BigIntMinAbs(longOrder.BaseAssetQuantity, liquidablePositions[0].Size)
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
+			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			lotp.On("ExecuteLiquidation", traderAddress, longOrder, expectedFillAmount).Return(nil)
 
 			orderMap := map[Market]*Orders{market: {[]Order{longOrder, longOrder2}, []Order{}}}
 
-			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices)
+			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 
 			lotp.AssertCalled(t, "ExecuteLiquidation", traderAddress, longOrder, expectedFillAmount)
 			cs.AssertCalled(t, "GetAcceptableBoundsForLiquidation", market)
@@ -99,6 +105,8 @@ func TestRunLiquidations(t *testing.T) {
 			orderMap := map[Market]*Orders{market: {[]Order{longOrder0, longOrder1}, []Order{shortOrder0, shortOrder1}}}
 
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
+			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			lotp.On("ExecuteLiquidation", traderAddress, orderMap[market].longOrders[0], big.NewInt(5)).Return(nil)
 			lotp.On("ExecuteLiquidation", traderAddress, orderMap[market].longOrders[1], big.NewInt(2)).Return(nil)
 			lotp.On("ExecuteLiquidation", traderAddress1, orderMap[market].longOrders[1], big.NewInt(9)).Return(nil)
@@ -106,7 +114,7 @@ func TestRunLiquidations(t *testing.T) {
 			lotp.On("ExecuteLiquidation", traderAddress1, orderMap[market].shortOrders[0], big.NewInt(1)).Return(nil)
 			lotp.On("ExecuteLiquidation", traderAddress1, orderMap[market].shortOrders[1], big.NewInt(1)).Return(nil)
 
-			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices)
+			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 			cs.AssertCalled(t, "GetAcceptableBoundsForLiquidation", market)
 
 			lotp.AssertCalled(t, "ExecuteLiquidation", traderAddress, longOrder0, big.NewInt(5))
@@ -144,7 +152,9 @@ func TestRunLiquidations(t *testing.T) {
 			orderMap := map[Market]*Orders{market: {longOrders, shortOrders}}
 
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices)
+			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetTakerFee").Return(big.NewInt(1e5))
+			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 			assert.Equal(t, longOrders, orderMap[market].longOrders)
 			assert.Equal(t, shortOrders, orderMap[market].shortOrders)
 			lotp.AssertNotCalled(t, "ExecuteLiquidation", mock.Anything, mock.Anything, mock.Anything)
@@ -157,9 +167,11 @@ func TestRunLiquidations(t *testing.T) {
 			expectedFillAmount := utils.BigIntMinAbs(shortOrder.BaseAssetQuantity, liquidablePositions[0].Size)
 			lotp.On("ExecuteLiquidation", traderAddress, shortOrder, expectedFillAmount).Return(nil)
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
+			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 
 			orderMap := map[Market]*Orders{market: {[]Order{longOrder}, []Order{shortOrder}}}
-			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices)
+			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 
 			lotp.AssertCalled(t, "ExecuteLiquidation", traderAddress, shortOrder, expectedFillAmount)
 			cs.AssertCalled(t, "GetAcceptableBoundsForLiquidation", market)
@@ -171,19 +183,22 @@ func TestRunLiquidations(t *testing.T) {
 }
 
 func TestRunMatchingEngine(t *testing.T) {
+	minAllowableMargin := big.NewInt(1e6)
+	takerFee := big.NewInt(1e6)
+	upperBound := big.NewInt(22)
 	t.Run("when either long or short orders are not present in memorydb", func(t *testing.T) {
 		t.Run("when no short and long orders are present", func(t *testing.T) {
 			_, lotp, pipeline, _, _ := setupDependencies(t)
 			longOrders := make([]Order, 0)
 			shortOrders := make([]Order, 0)
-			pipeline.runMatchingEngine(lotp, longOrders, shortOrders)
+			pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
 			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
 		})
 		t.Run("when longOrders are not present but short orders are present", func(t *testing.T) {
 			_, lotp, pipeline, _, _ := setupDependencies(t)
 			longOrders := make([]Order, 0)
 			shortOrders := []Order{getShortOrder()}
-			pipeline.runMatchingEngine(lotp, longOrders, shortOrders)
+			pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
 			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
 		})
 		t.Run("when short orders are not present but long orders are present", func(t *testing.T) {
@@ -195,7 +210,7 @@ func TestRunMatchingEngine(t *testing.T) {
 			db.On("GetLongOrders").Return(longOrders)
 			db.On("GetShortOrders").Return(shortOrders)
 			lotp.On("PurgeLocalTx").Return(nil)
-			pipeline.runMatchingEngine(lotp, longOrders, shortOrders)
+			pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
 			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
 		})
 	})
@@ -206,7 +221,7 @@ func TestRunMatchingEngine(t *testing.T) {
 			longOrder := getLongOrder()
 			longOrder.Price.Sub(shortOrder.Price, big.NewInt(1))
 
-			pipeline.runMatchingEngine(lotp, []Order{longOrder}, []Order{shortOrder})
+			pipeline.runMatchingEngine(lotp, []Order{longOrder}, []Order{shortOrder}, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
 			lotp.AssertNotCalled(t, "ExecuteMatchedOrdersTx", mock.Anything, mock.Anything, mock.Anything)
 		})
 		t.Run("When longOrder.Price >= shortOrder.Price same", func(t *testing.T) {
@@ -231,7 +246,7 @@ func TestRunMatchingEngine(t *testing.T) {
 					fillAmount2 := longOrder2.BaseAssetQuantity
 					lotp.On("ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1).Return(nil)
 					lotp.On("ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2).Return(nil)
-					pipeline.runMatchingEngine(lotp, longOrders, shortOrders)
+					pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2)
 				})
@@ -256,7 +271,7 @@ func TestRunMatchingEngine(t *testing.T) {
 					db.On("GetShortOrders").Return(shortOrders)
 					lotp.On("PurgeLocalTx").Return(nil)
 					lotp.On("ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount).Return(nil)
-					pipeline.runMatchingEngine(lotp, longOrders, shortOrders)
+					pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount)
 				})
 			})
@@ -293,7 +308,7 @@ func TestRunMatchingEngine(t *testing.T) {
 				db.On("GetShortOrders").Return(shortOrders)
 				lotp.On("PurgeLocalTx").Return(nil)
 				log.Info("longOrder1", "longOrder1", longOrder1)
-				pipeline.runMatchingEngine(lotp, longOrders, shortOrders)
+				pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
 				log.Info("longOrder1", "longOrder1", longOrder1)
 
 				//During 1st  matching iteration
@@ -492,6 +507,11 @@ func TestMatchLongAndShortOrder(t *testing.T) {
 }
 
 func TestAreMatchingOrders(t *testing.T) {
+	marginMap := map[common.Address]*big.Int{}
+	minAllowableMargin := big.NewInt(1e6)
+	takerFee := big.NewInt(1e6)
+	upperBound := big.NewInt(22)
+
 	trader := common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa")
 	longOrder_ := Order{
 		Market:                  1,
@@ -547,7 +567,7 @@ func TestAreMatchingOrders(t *testing.T) {
 		shortOrder := deepCopyOrder(&shortOrder_)
 
 		longOrder.Price = big.NewInt(80)
-		actualFillAmount := areMatchingOrders(longOrder, shortOrder)
+		actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 
 		assert.Nil(t, actualFillAmount)
 	})
@@ -566,7 +586,7 @@ func TestAreMatchingOrders(t *testing.T) {
 				ExpireAt:  big.NewInt(0),
 			}
 
-			actualFillAmount := areMatchingOrders(longOrder, shortOrder)
+			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
 		t.Run("short order is post only", func(t *testing.T) {
@@ -575,7 +595,7 @@ func TestAreMatchingOrders(t *testing.T) {
 
 			shortOrder.RawOrder.(*LimitOrder).PostOnly = true
 
-			actualFillAmount := areMatchingOrders(longOrder, shortOrder)
+			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
 	})
@@ -594,7 +614,7 @@ func TestAreMatchingOrders(t *testing.T) {
 				ExpireAt:  big.NewInt(0),
 			}
 
-			actualFillAmount := areMatchingOrders(longOrder, shortOrder)
+			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
 		t.Run("longOrder is post only", func(t *testing.T) {
@@ -603,7 +623,7 @@ func TestAreMatchingOrders(t *testing.T) {
 
 			longOrder.RawOrder.(*LimitOrder).PostOnly = true
 
-			actualFillAmount := areMatchingOrders(longOrder, shortOrder)
+			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
 	})
@@ -613,7 +633,7 @@ func TestAreMatchingOrders(t *testing.T) {
 		shortOrder := deepCopyOrder(&shortOrder_)
 
 		longOrder.FilledBaseAssetQuantity = longOrder.BaseAssetQuantity
-		actualFillAmount := areMatchingOrders(longOrder, shortOrder)
+		actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 		assert.Nil(t, actualFillAmount)
 	})
 
@@ -622,7 +642,7 @@ func TestAreMatchingOrders(t *testing.T) {
 		shortOrder := deepCopyOrder(&shortOrder_)
 
 		longOrder.FilledBaseAssetQuantity = big.NewInt(5)
-		actualFillAmount := areMatchingOrders(longOrder, shortOrder)
+		actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 		assert.Equal(t, big.NewInt(5), actualFillAmount)
 	})
 }

--- a/plugin/evm/orderbook/matching_pipeline_test.go
+++ b/plugin/evm/orderbook/matching_pipeline_test.go
@@ -244,9 +244,12 @@ func TestRunMatchingEngine(t *testing.T) {
 
 					fillAmount1 := longOrder1.BaseAssetQuantity
 					fillAmount2 := longOrder2.BaseAssetQuantity
+					marginMap := map[common.Address]*big.Int{
+						common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+					}
 					lotp.On("ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1).Return(nil)
 					lotp.On("ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2).Return(nil)
-					pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
+					pipeline.runMatchingEngine(lotp, longOrders, shortOrders, marginMap, minAllowableMargin, takerFee, upperBound)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder1, shortOrder1, fillAmount1)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder2, shortOrder2, fillAmount2)
 				})
@@ -271,7 +274,10 @@ func TestRunMatchingEngine(t *testing.T) {
 					db.On("GetShortOrders").Return(shortOrders)
 					lotp.On("PurgeLocalTx").Return(nil)
 					lotp.On("ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount).Return(nil)
-					pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
+					marginMap := map[common.Address]*big.Int{
+						common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+					}
+					pipeline.runMatchingEngine(lotp, longOrders, shortOrders, marginMap, minAllowableMargin, takerFee, upperBound)
 					lotp.AssertCalled(t, "ExecuteMatchedOrdersTx", longOrder, shortOrder, fillAmount)
 				})
 			})
@@ -308,7 +314,10 @@ func TestRunMatchingEngine(t *testing.T) {
 				db.On("GetShortOrders").Return(shortOrders)
 				lotp.On("PurgeLocalTx").Return(nil)
 				log.Info("longOrder1", "longOrder1", longOrder1)
-				pipeline.runMatchingEngine(lotp, longOrders, shortOrders, map[common.Address]*big.Int{}, minAllowableMargin, takerFee, upperBound)
+				marginMap := map[common.Address]*big.Int{
+					common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+				}
+				pipeline.runMatchingEngine(lotp, longOrders, shortOrders, marginMap, minAllowableMargin, takerFee, upperBound)
 				log.Info("longOrder1", "longOrder1", longOrder1)
 
 				//During 1st  matching iteration
@@ -507,7 +516,6 @@ func TestMatchLongAndShortOrder(t *testing.T) {
 }
 
 func TestAreMatchingOrders(t *testing.T) {
-	marginMap := map[common.Address]*big.Int{}
 	minAllowableMargin := big.NewInt(1e6)
 	takerFee := big.NewInt(1e6)
 	upperBound := big.NewInt(22)
@@ -567,6 +575,9 @@ func TestAreMatchingOrders(t *testing.T) {
 		shortOrder := deepCopyOrder(&shortOrder_)
 
 		longOrder.Price = big.NewInt(80)
+		marginMap := map[common.Address]*big.Int{
+			common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+		}
 		actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 
 		assert.Nil(t, actualFillAmount)
@@ -585,7 +596,9 @@ func TestAreMatchingOrders(t *testing.T) {
 				OrderType: 1,
 				ExpireAt:  big.NewInt(0),
 			}
-
+			marginMap := map[common.Address]*big.Int{
+				common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+			}
 			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
@@ -594,7 +607,9 @@ func TestAreMatchingOrders(t *testing.T) {
 			longOrder.BlockNumber = big.NewInt(20)
 
 			shortOrder.RawOrder.(*LimitOrder).PostOnly = true
-
+			marginMap := map[common.Address]*big.Int{
+				common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+			}
 			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
@@ -613,7 +628,9 @@ func TestAreMatchingOrders(t *testing.T) {
 				OrderType: 1,
 				ExpireAt:  big.NewInt(0),
 			}
-
+			marginMap := map[common.Address]*big.Int{
+				common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+			}
 			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
@@ -622,7 +639,9 @@ func TestAreMatchingOrders(t *testing.T) {
 			longOrder.BlockNumber = big.NewInt(21)
 
 			longOrder.RawOrder.(*LimitOrder).PostOnly = true
-
+			marginMap := map[common.Address]*big.Int{
+				common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+			}
 			actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 			assert.Nil(t, actualFillAmount)
 		})
@@ -633,6 +652,9 @@ func TestAreMatchingOrders(t *testing.T) {
 		shortOrder := deepCopyOrder(&shortOrder_)
 
 		longOrder.FilledBaseAssetQuantity = longOrder.BaseAssetQuantity
+		marginMap := map[common.Address]*big.Int{
+			common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+		}
 		actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 		assert.Nil(t, actualFillAmount)
 	})
@@ -642,6 +664,9 @@ func TestAreMatchingOrders(t *testing.T) {
 		shortOrder := deepCopyOrder(&shortOrder_)
 
 		longOrder.FilledBaseAssetQuantity = big.NewInt(5)
+		marginMap := map[common.Address]*big.Int{
+			common.HexToAddress("0x22Bb736b64A0b4D4081E103f83bccF864F0404aa"): big.NewInt(1e9), // $1000
+		}
 		actualFillAmount := areMatchingOrders(longOrder, shortOrder, marginMap, minAllowableMargin, takerFee, upperBound)
 		assert.Equal(t, big.NewInt(5), actualFillAmount)
 	})

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -433,7 +433,7 @@ func TestGetCancellableOrders(t *testing.T) {
 	availableMargin := getAvailableMargin(_trader, hState)
 	// availableMargin = 40 - 9 - (99 + (10+9+8) * 3)/5 = -5
 	assert.Equal(t, hu.Mul1e6(big.NewInt(-5)), availableMargin)
-	_, ordersToCancel := inMemoryDatabase.GetNaughtyTraders(hState)
+	_, ordersToCancel, _ := inMemoryDatabase.GetNaughtyTraders(hState)
 
 	// t.Log("####", "ordersToCancel", ordersToCancel)
 	assert.Equal(t, 1, len(ordersToCancel)) // only one trader

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -18,6 +18,7 @@ var (
 	orderBookTransactionsFailureTotalCounter = metrics.NewRegisteredCounter("orderbooktxs/total/failure", nil)
 
 	// panics are recovered but monitored
+	AllPanicsCounter                         = metrics.NewRegisteredCounter("all_panics", nil)
 	RunMatchingPipelinePanicsCounter         = metrics.NewRegisteredCounter("matching_pipeline_panics", nil)
 	HandleHubbleFeedLogsPanicsCounter        = metrics.NewRegisteredCounter("handle_hubble_feed_logs_panics", nil)
 	HandleChainAcceptedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -31,4 +31,7 @@ var (
 
 	// order id not found while deleting
 	deleteOrderIdNotFoundCounter = metrics.NewRegisteredCounter("delete_order_id_not_found", nil)
+
+	// unquenched liquidations
+	unquenchedLiquidationsCounter = metrics.NewRegisteredCounter("unquenched_liquidations", nil)
 )

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -116,8 +116,8 @@ func (db *MockLimitOrderDatabase) GetLastPrices() map[Market]*big.Int {
 	return map[Market]*big.Int{}
 }
 
-func (db *MockLimitOrderDatabase) GetNaughtyTraders(hState *hu.HubbleState) ([]LiquidablePosition, map[common.Address][]Order) {
-	return []LiquidablePosition{}, map[common.Address][]Order{}
+func (db *MockLimitOrderDatabase) GetNaughtyTraders(hState *hu.HubbleState) ([]LiquidablePosition, map[common.Address][]Order, map[common.Address]*big.Int) {
+	return []LiquidablePosition{}, map[common.Address][]Order{}, map[common.Address]*big.Int{}
 }
 
 func (db *MockLimitOrderDatabase) GetOrderBookData() InMemoryDatabase {
@@ -285,6 +285,10 @@ func (cs *MockConfigService) GetCumulativePremiumFractionAtBlock(market Market, 
 
 func (cs *MockConfigService) GetCollaterals() []hu.Collateral {
 	return []hu.Collateral{{Price: big.NewInt(1e6), Weight: big.NewInt(1e6), Decimals: 6}}
+}
+
+func (cs *MockConfigService) GetTakerFee() *big.Int {
+	return big.NewInt(0)
 }
 
 func NewMockConfigService() *MockConfigService {

--- a/utils/string.go
+++ b/utils/string.go
@@ -1,5 +1,10 @@
 package utils
 
+import (
+	"strings"
+	"unicode"
+)
+
 func ContainsString(list []string, item string) bool {
 	for _, i := range list {
 		if i == item {
@@ -7,4 +12,14 @@ func ContainsString(list []string, item string) bool {
 		}
 	}
 	return false
+}
+
+func RemoveSpacesAndSpecialChars(str string) string {
+	var builder strings.Builder
+	for _, r := range str {
+		if unicode.IsLetter(r) || unicode.IsNumber(r) {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
 }


### PR DESCRIPTION
## Why this should be merged
1. Added a filter in matching pipeline that checks for margin requirements of IOC orders
2. Added metric for unquenched liquidations
3. Added metric for OrderMatchingError on combination of order type and error message

## How this works

## How this was tested
Not tested yet

## How is this documented
