### PR TITLE
Delete expired signed orders and virtual reserved margin

### DIFF
--- a/plugin/evm/orderbook/abis/SignedOrderBook.go
+++ b/plugin/evm/orderbook/abis/SignedOrderBook.go
@@ -1,0 +1,510 @@
+package abis
+
+var SignedOrderBookAbi = []byte(`{"abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_defaultOrderBook",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "trader",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "orderHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "OrderCancelAccepted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "trader",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "orderHash",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "timestamp",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "err",
+          "type": "string"
+        }
+      ],
+      "name": "OrderCancelRejected",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "ORDER_TYPEHASH",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "orderType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "expireAt",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "ammIndex",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "trader",
+              "type": "address"
+            },
+            {
+              "internalType": "int256",
+              "name": "baseAssetQuantity",
+              "type": "int256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "price",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "salt",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "reduceOnly",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "postOnly",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct ISignedOrderBook.Order[]",
+          "name": "orders",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "bytes[]",
+          "name": "signatures",
+          "type": "bytes[]"
+        }
+      ],
+      "name": "cancelOrders",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "defaultOrderBook",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "orderType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "expireAt",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "ammIndex",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "trader",
+              "type": "address"
+            },
+            {
+              "internalType": "int256",
+              "name": "baseAssetQuantity",
+              "type": "int256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "price",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "salt",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "reduceOnly",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "postOnly",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct ISignedOrderBook.Order",
+          "name": "order",
+          "type": "tuple"
+        }
+      ],
+      "name": "getOrderHash",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "governance",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_governance",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_juror",
+          "type": "address"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "trader",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "isTradingAuthority",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "juror",
+      "outputs": [
+        {
+          "internalType": "contract IJuror",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "name": "orderInfo",
+      "outputs": [
+        {
+          "internalType": "int256",
+          "name": "filledAmount",
+          "type": "int256"
+        },
+        {
+          "internalType": "enum IOrderHandler.OrderStatus",
+          "name": "status",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "orderHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "orderStatus",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "int256",
+              "name": "filledAmount",
+              "type": "int256"
+            },
+            {
+              "internalType": "enum IOrderHandler.OrderStatus",
+              "name": "status",
+              "type": "uint8"
+            }
+          ],
+          "internalType": "struct ISignedOrderBook.OrderInfo",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "__governance",
+          "type": "address"
+        }
+      ],
+      "name": "setGovernace",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "encodedOrder",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes",
+          "name": "metadata",
+          "type": "bytes"
+        }
+      ],
+      "name": "updateOrder",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint8",
+              "name": "orderType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "expireAt",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "ammIndex",
+              "type": "uint256"
+            },
+            {
+              "internalType": "address",
+              "name": "trader",
+              "type": "address"
+            },
+            {
+              "internalType": "int256",
+              "name": "baseAssetQuantity",
+              "type": "int256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "price",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "salt",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "reduceOnly",
+              "type": "bool"
+            },
+            {
+              "internalType": "bool",
+              "name": "postOnly",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct ISignedOrderBook.Order",
+          "name": "order",
+          "type": "tuple"
+        },
+        {
+          "internalType": "bytes",
+          "name": "signature",
+          "type": "bytes"
+        }
+      ],
+      "name": "verifySigner",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "signer",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "orderHash",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]}`)

--- a/plugin/evm/orderbook/hubbleutils/hubble_math.go
+++ b/plugin/evm/orderbook/hubbleutils/hubble_math.go
@@ -64,6 +64,10 @@ func Mod(a, b *big.Int) *big.Int {
 	return new(big.Int).Mod(a, b)
 }
 
+func Neg(a *big.Int) *big.Int {
+	return new(big.Int).Neg(a)
+}
+
 func Scale(a *big.Int, decimals uint8) *big.Int {
 	return Mul(a, new(big.Int).Exp(big.NewInt(10), big.NewInt(int64(decimals)), nil))
 }

--- a/plugin/evm/orderbook/hubbleutils/margin_math.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math.go
@@ -156,6 +156,6 @@ func WeightedAndSpotCollateral(assets []Collateral, margins []*big.Int) (weighte
 }
 
 func GetRequiredMargin(price, fillAmount, minAllowableMargin, takerFee *big.Int) *big.Int {
-	quoteAsset := Div1e18(Abs(Mul(fillAmount, price)))
+	quoteAsset := Div1e18(Mul(fillAmount, price))
 	return Add(Div1e6(Mul(quoteAsset, minAllowableMargin)), Div1e6(Mul(quoteAsset, takerFee)))
 }

--- a/plugin/evm/orderbook/hubbleutils/margin_math.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math.go
@@ -156,6 +156,6 @@ func WeightedAndSpotCollateral(assets []Collateral, margins []*big.Int) (weighte
 }
 
 func GetRequiredMargin(price, fillAmount, minAllowableMargin, takerFee *big.Int) *big.Int {
-	quoteAsset := Div1e18(Mul(fillAmount, price))
+	quoteAsset := Div1e18(Abs(Mul(fillAmount, price)))
 	return Add(Div1e6(Mul(quoteAsset, minAllowableMargin)), Div1e6(Mul(quoteAsset, takerFee)))
 }

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -324,7 +324,7 @@ func areMatchingOrders(longOrder, shortOrder Order, marginMap map[common.Address
 		return nil
 	}
 
-	shortMargin := big.NewInt(0)
+	var shortMargin *big.Int = big.NewInt(0)
 	_isExecutable, shortMargin = isExecutable(&shortOrder, fillAmount, minAllowableMargin, takerFee, upperBound, marginMap[longOrder.Trader])
 	if !_isExecutable {
 		return nil

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -338,8 +338,12 @@ func isExecutable(order *Order, fillAmount, minAllowableMargin, takerFee, upperB
 	if order.OrderType == Limit || order.ReduceOnly {
 		return true, big.NewInt(0) // no extra margin required because for limit orders it is already reserved
 	}
-	if order.OrderType == IOC || order.OrderType == Signed {
+	if order.OrderType == IOC {
 		requiredMargin := getRequiredMargin(order, fillAmount, minAllowableMargin, takerFee, upperBound)
+		return requiredMargin.Cmp(availableMargin) <= 0, requiredMargin
+	}
+	if order.OrderType == Signed {
+		requiredMargin := getRequiredMargin(order, fillAmount, minAllowableMargin, big.NewInt(0) /* signed orders are always maker */, upperBound)
 		return requiredMargin.Cmp(availableMargin) <= 0, requiredMargin
 	}
 	return false, big.NewInt(0)

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -54,6 +54,9 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	// start fresh and purge all local transactions
 	pipeline.lotp.PurgeOrderBookTxs()
 
+	// remove expired signed orders
+	pipeline.db.RemoveExpiredSignedOrders()
+
 	if isFundingPaymentTime(pipeline.db.GetNextFundingTime()) {
 		log.Info("MatchingPipeline:isFundingPaymentTime")
 		err := executeFundingPayment(pipeline.lotp)

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -618,10 +618,6 @@ func (db *InMemoryDatabase) UpdateFilledBaseAssetQuantity(quantity *big.Int, ord
 
 	// only update margin if the order is not reduce-only
 	if order.OrderType == Signed && !order.ReduceOnly {
-		// for short orders, quantity is negative when filled and positive when event was removed
-		if order.PositionType == SHORT {
-			quantity = hu.Neg(quantity)
-		}
 		minAllowableMargin := db.configService.getMinAllowableMargin()
 		requiredMargin := hu.GetRequiredMargin(order.Price, quantity, minAllowableMargin, big.NewInt(0))
 		db.updateVirtualReservedMargin(order.Trader, hu.Neg(requiredMargin))

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -395,8 +395,9 @@ func (db *InMemoryDatabase) RemoveExpiredSignedOrders() {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
+	now := time.Now().Unix()
 	for _, order := range db.Orders {
-		if order.OrderType == Signed && order.getExpireAt().Int64() < time.Now().Unix() {
+		if order.OrderType == Signed && order.getExpireAt().Int64() <= now {
 			db.deleteOrderWithoutLock(order.Id)
 		}
 	}

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -1024,6 +1024,7 @@ func (db *InMemoryDatabase) GetNaughtyTraders(hState *hu.HubbleState) ([]Liquida
 		}
 		marginFraction := hu.GetMarginFraction(hState, userState)
 		db.TraderMap[addr].Margin.Available = hu.GetAvailableMargin(hState, userState)
+		marginMap[addr] = new(big.Int).Set(db.TraderMap[addr].Margin.Available)
 		if marginFraction.Cmp(hState.MaintenanceMargin) == -1 {
 			log.Info("below maintenanceMargin", "trader", addr.String(), "marginFraction", prettifyScaledBigInt(marginFraction, 6))
 			if len(minSizes) == 0 {

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -168,6 +168,8 @@ func (db *MockLimitOrderDatabase) SampleImpactPrice() (impactBids, impactAsks, m
 	return []*big.Int{}, []*big.Int{}, []*big.Int{}
 }
 
+func (db *MockLimitOrderDatabase) RemoveExpiredSignedOrders() {}
+
 type MockLimitOrderTxProcessor struct {
 	mock.Mock
 }

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -337,5 +337,5 @@ func (cs *MockConfigService) GetMarketAddressFromMarketID(marketId int64) common
 }
 
 func (cs *MockConfigService) GetImpactMarginNotional(ammAddress common.Address) *big.Int {
-	return big.NewInt(0)
+	return big.NewInt(500e6)
 }

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -350,7 +350,7 @@ func (api *TradingAPI) PlaceOrder(order *hu.SignedOrder) (common.Hash, error) {
 		// P2. Margin is available for non-reduce only orders
 		minAllowableMargin := api.configService.getMinAllowableMargin()
 		// even tho order might be matched at a different price, we reserve margin at the price the order was placed at to keep it simple
-		requiredMargin = hu.GetRequiredMargin(order.Price, order.BaseAssetQuantity, minAllowableMargin, big.NewInt(0))
+		requiredMargin = hu.GetRequiredMargin(order.Price, hu.Abs(order.BaseAssetQuantity), minAllowableMargin, big.NewInt(0))
 		if fields.AvailableMargin.Cmp(requiredMargin) == -1 {
 			return orderId, hu.ErrInsufficientMargin
 		}

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -350,7 +350,7 @@ func (api *TradingAPI) PlaceOrder(order *hu.SignedOrder) (common.Hash, error) {
 		// P2. Margin is available for non-reduce only orders
 		minAllowableMargin := api.configService.getMinAllowableMargin()
 		// even tho order might be matched at a different price, we reserve margin at the price the order was placed at to keep it simple
-		requiredMargin = hu.GetRequiredMargin(order.Price, hu.Abs(order.BaseAssetQuantity), minAllowableMargin, big.NewInt(0))
+		requiredMargin = hu.GetRequiredMargin(order.Price, order.BaseAssetQuantity, minAllowableMargin, big.NewInt(0))
 		if fields.AvailableMargin.Cmp(requiredMargin) == -1 {
 			return orderId, hu.ErrInsufficientMargin
 		}

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -29,6 +29,7 @@ var MarginAccountContractAddress = common.HexToAddress("0x0300000000000000000000
 var ClearingHouseContractAddress = common.HexToAddress("0x03000000000000000000000000000000000000b2")
 var LimitOrderBookContractAddress = common.HexToAddress("0x03000000000000000000000000000000000000b3")
 var IOCOrderBookContractAddress = common.HexToAddress("0x03000000000000000000000000000000000000b4")
+var SignedOrderBookContractAddress = common.HexToAddress("0x36C02dA8a0983159322a80FFE9F24b1acfF8B570") // @todo: set the correct address
 
 type LimitOrderTxProcessor interface {
 	GetOrderBookTxsCount() uint64

--- a/subnet.json
+++ b/subnet.json
@@ -1,3 +1,3 @@
 {
-    "proposerMinBlockDelay": 0
+    "proposerMinBlockDelay": 200000000
 }


### PR DESCRIPTION
## Why this should be merged
- Delete signed orders based on expiry at every run of matching engine
- Handle SignedOrderBook's CancelOrderAccepted
- Add signed order creation and cancellation to trader feed
- Reduce the virtual reserved margin when order is matched and deleted
- Add tests for SampleImpactPrice

## How this works

## How this was tested

## How is this documented
