### PR TITLE
Makerbook fixes

### DIFF
--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	memoryDBSnapshotKey string = "memoryDBSnapshot"
-	snapshotInterval    uint64 = 10 // save snapshot every 10 blocks
+	snapshotInterval    uint64 = 1000 // save snapshot every 1000 blocks
 )
 
 type LimitOrderProcesser interface {
@@ -74,8 +74,10 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownCh
 	filterAPI := filters.NewFilterAPI(filterSystem)
 
 	// need to register the types for gob encoding because memory DB has an interface field(ContractOrder)
-	gob.Register(&hu.LimitOrder{})
-	gob.Register(&hu.IOCOrder{})
+	// naming hu.LimitOrder as orderbook.LimitOrder instead of hubbleutils.LimitOrder because of backward compatibility. DO NOT CHANGE
+	// same for hu.IOCOrder
+	gob.RegisterName("*orderbook.LimitOrder", &hu.LimitOrder{})
+	gob.RegisterName("*orderbook.IOCOrder", &hu.IOCOrder{})
 	gob.Register(&hu.SignedOrder{})
 	return &limitOrderProcesser{
 		ctx:                     ctx,

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -1296,7 +1296,7 @@ func (db *InMemoryDatabase) GetOrderValidationFields(orderId common.Hash, order 
 			db.TraderMap[trader].Margin.Available = big.NewInt(0)
 		}
 		if db.TraderMap[trader].Margin.VirtualReserved == nil {
-			db.TraderMap[trader].Margin.Available = big.NewInt(0)
+			db.TraderMap[trader].Margin.VirtualReserved = big.NewInt(0)
 		}
 		availableMargin = hu.Sub(db.TraderMap[trader].Margin.Available /* as fresh as the last matching engine run */, db.TraderMap[trader].Margin.VirtualReserved)
 	}

--- a/subnet.json
+++ b/subnet.json
@@ -1,3 +1,6 @@
 {
-    "proposerMinBlockDelay": 200000000
+    "proposerMinBlockDelay": 200000000,
+    "appGossipValidatorSize": 10,
+    "appGossipNonValidatorSize": 5,
+    "appGossipPeerSize": 15
 }


### PR DESCRIPTION
## Why this should be merged
- Use gob encoding for gossiping orders instead of rlp. It fixes the gossiping error of short orders.
- Fix loading of snapshot.
- Allow gossiping to non validators. By default it's not allowed. It can be configured on node level and subnet level; this change modified it at subnet level 

## How this was tested
On aylin
