### PR TITLE
cache hubble state

### DIFF
--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	memoryDBSnapshotKey string = "memoryDBSnapshot"
-	snapshotInterval    uint64 = 1000 // save snapshot every 1000 blocks
+	snapshotInterval    uint64 = 10 // save snapshot every 1000 blocks
 )
 
 type LimitOrderProcesser interface {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -68,8 +68,20 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownCh
 	lotp := orderbook.NewLimitOrderTxProcessor(txPool, memoryDb, backend, validatorPrivateKey)
 	signedObAddy := configService.GetSignedOrderbookContract()
 	contractEventProcessor := orderbook.NewContractEventsProcessor(memoryDb, signedObAddy)
-	hu.SetChainIdAndVerifyingSignedOrdersContract(backend.ChainConfig().ChainID.Int64(), signedObAddy.String())
+
 	matchingPipeline := orderbook.NewMatchingPipeline(memoryDb, lotp, configService)
+	// if any of the following values are changed, the nodes will need to be restarted
+	hState := &hu.HubbleState{
+		Assets:             matchingPipeline.GetCollaterals(),
+		ActiveMarkets:      matchingPipeline.GetActiveMarkets(),
+		MinAllowableMargin: configService.GetMinAllowableMargin(),
+		MaintenanceMargin:  configService.GetMaintenanceMargin(),
+		TakerFee:           configService.GetTakerFee(),
+		UpgradeVersion:     configService.GetUpgradeVersion(),
+	}
+	hu.SetHubbleState(hState)
+	hu.SetChainIdAndVerifyingSignedOrdersContract(backend.ChainConfig().ChainID.Int64(), signedObAddy.String())
+
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{})
 	filterAPI := filters.NewFilterAPI(filterSystem)
 
@@ -167,6 +179,12 @@ func (lop *limitOrderProcesser) RunMatchingPipeline() {
 			lop.blockBuilder.signalTxsReady()
 		}
 	}, orderbook.RunMatchingPipelinePanicMessage, orderbook.RunMatchingPipelinePanicsCounter)
+}
+
+func (lop *limitOrderProcesser) RunSanitaryPipeline() {
+	executeFuncAndRecoverPanic(func() {
+		lop.matchingPipeline.RunSanitization()
+	}, orderbook.RunSanitaryPipelinePanicMessage, orderbook.RunSanitaryPipelinePanicsCounter)
 }
 
 func (lop *limitOrderProcesser) GetOrderBookAPI() *orderbook.OrderBookAPI {
@@ -318,6 +336,9 @@ func (lop *limitOrderProcesser) runMatchingTimer() {
 			select {
 			case <-lop.matchingPipeline.MatchingTicker.C:
 				lop.RunMatchingPipeline()
+
+			case <-lop.matchingPipeline.SanitaryTicker.C:
+				lop.RunSanitaryPipeline()
 
 			case <-lop.shutdownChan:
 				lop.matchingPipeline.MatchingTicker.Stop()

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -13,8 +13,8 @@ import (
 type IConfigService interface {
 	getMaxLiquidationRatio(market Market) *big.Int
 	getLiquidationSpreadThreshold(market Market) *big.Int
-	getMinAllowableMargin() *big.Int
-	getMaintenanceMargin() *big.Int
+	GetMinAllowableMargin() *big.Int
+	GetMaintenanceMargin() *big.Int
 	getMinSizeRequirement(market Market) *big.Int
 	GetPriceMultiplier(market Market) *big.Int
 	GetActiveMarketsCount() int64
@@ -64,11 +64,11 @@ func (cs *ConfigService) getMaxLiquidationRatio(market Market) *big.Int {
 	return bibliophile.GetMaxLiquidationRatio(cs.getStateAtCurrentBlock(), int64(market))
 }
 
-func (cs *ConfigService) getMinAllowableMargin() *big.Int {
+func (cs *ConfigService) GetMinAllowableMargin() *big.Int {
 	return bibliophile.GetMinAllowableMargin(cs.getStateAtCurrentBlock())
 }
 
-func (cs *ConfigService) getMaintenanceMargin() *big.Int {
+func (cs *ConfigService) GetMaintenanceMargin() *big.Int {
 	return bibliophile.GetMaintenanceMargin(cs.getStateAtCurrentBlock())
 }
 

--- a/plugin/evm/orderbook/errors.go
+++ b/plugin/evm/orderbook/errors.go
@@ -5,4 +5,5 @@ const (
 	HandleChainAcceptedLogsPanicMessage  = "panic while processing chainAcceptedLogs"
 	HandleHubbleFeedLogsPanicMessage     = "panic while processing hubbleFeedLogs"
 	RunMatchingPipelinePanicMessage      = "panic while running matching pipeline"
+	RunSanitaryPipelinePanicMessage      = "panic while running sanitary pipeline"
 )

--- a/plugin/evm/orderbook/hubbleutils/config.go
+++ b/plugin/evm/orderbook/hubbleutils/config.go
@@ -1,0 +1,16 @@
+package hubbleutils
+
+var (
+	ChainId           int64
+	VerifyingContract string
+	HState            *HubbleState
+)
+
+func SetChainIdAndVerifyingSignedOrdersContract(chainId int64, verifyingContract string) {
+	ChainId = chainId
+	VerifyingContract = verifyingContract
+}
+
+func SetHubbleState(hState *HubbleState) {
+	HState = hState
+}

--- a/plugin/evm/orderbook/hubbleutils/signed_orders.go
+++ b/plugin/evm/orderbook/hubbleutils/signed_orders.go
@@ -21,16 +21,6 @@ type SignedOrder struct {
 	Sig       []byte   `json:"sig"`
 }
 
-var (
-	ChainId           int64
-	VerifyingContract string
-)
-
-func SetChainIdAndVerifyingSignedOrdersContract(chainId int64, verifyingContract string) {
-	ChainId = chainId
-	VerifyingContract = verifyingContract
-}
-
 func (order *SignedOrder) EncodeToABIWithoutType() ([]byte, error) {
 	signedOrderType, err := getOrderType("signed")
 	if err != nil {

--- a/plugin/evm/orderbook/liquidations_test.go
+++ b/plugin/evm/orderbook/liquidations_test.go
@@ -19,7 +19,7 @@ func TestGetLiquidableTraders(t *testing.T) {
 			Assets:             assets,
 			OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))},
 			ActiveMarkets:      []hu.Market{market},
-			MinAllowableMargin: db.configService.getMinAllowableMargin(),
+			MinAllowableMargin: db.configService.GetMinAllowableMargin(),
 		}
 		liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 		assert.Equal(t, 0, len(liquidablePositions))
@@ -43,8 +43,8 @@ func TestGetLiquidableTraders(t *testing.T) {
 			OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(110))},
 			MidPrices:          map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(100))},
 			ActiveMarkets:      []hu.Market{market},
-			MaintenanceMargin:  db.configService.getMaintenanceMargin(),
-			MinAllowableMargin: db.configService.getMinAllowableMargin(),
+			MaintenanceMargin:  db.configService.GetMaintenanceMargin(),
+			MinAllowableMargin: db.configService.GetMinAllowableMargin(),
 		}
 		liquidablePositions, _, _ := db.GetNaughtyTraders(hState)
 		assert.Equal(t, 0, len(liquidablePositions))
@@ -77,8 +77,8 @@ func TestGetLiquidableTraders(t *testing.T) {
 				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(50))},
 				MidPrices:          map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(49))},
 				ActiveMarkets:      []hu.Market{market},
-				MinAllowableMargin: db.configService.getMinAllowableMargin(),
-				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
+				MinAllowableMargin: db.configService.GetMinAllowableMargin(),
+				MaintenanceMargin:  db.configService.GetMaintenanceMargin(),
 				UpgradeVersion:     hu.V2,
 			}
 			oraclePrices := hState.OraclePrices
@@ -136,8 +136,8 @@ func TestGetLiquidableTraders(t *testing.T) {
 				OraclePrices:       map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(142))},
 				MidPrices:          map[Market]*big.Int{market: hu.Mul1e6(big.NewInt(143))},
 				ActiveMarkets:      []hu.Market{market},
-				MinAllowableMargin: db.configService.getMinAllowableMargin(),
-				MaintenanceMargin:  db.configService.getMaintenanceMargin(),
+				MinAllowableMargin: db.configService.GetMinAllowableMargin(),
+				MaintenanceMargin:  db.configService.GetMaintenanceMargin(),
 			}
 			oraclePrices := hState.OraclePrices
 
@@ -273,8 +273,8 @@ func getPosition(market Market, openNotional *big.Int, size *big.Int, unrealized
 
 func getDatabase() *InMemoryDatabase {
 	configService := NewMockConfigService()
-	configService.Mock.On("getMaintenanceMargin").Return(big.NewInt(1e5))
-	configService.Mock.On("getMinAllowableMargin").Return(big.NewInt(2e5))
+	configService.Mock.On("GetMaintenanceMargin").Return(big.NewInt(1e5))
+	configService.Mock.On("GetMinAllowableMargin").Return(big.NewInt(2e5))
 	configService.Mock.On("getMaxLiquidationRatio").Return(big.NewInt(1e6))
 	configService.Mock.On("getMinSizeRequirement").Return(big.NewInt(1e16))
 

--- a/plugin/evm/orderbook/matching_pipeline_test.go
+++ b/plugin/evm/orderbook/matching_pipeline_test.go
@@ -41,7 +41,7 @@ func TestRunLiquidations(t *testing.T) {
 			orderMap := map[Market]*Orders{market: {longOrders, shortOrders}}
 
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetMinAllowableMargin").Return(big.NewInt(1e5))
 			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			pipeline.runLiquidations([]LiquidablePosition{getLiquidablePos(traderAddress, LONG, 7)}, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 			assert.Equal(t, longOrders, orderMap[market].longOrders)
@@ -56,7 +56,7 @@ func TestRunLiquidations(t *testing.T) {
 			shortOrder := getShortOrder()
 			expectedFillAmount := utils.BigIntMinAbs(longOrder.BaseAssetQuantity, liquidablePositions[0].Size)
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetMinAllowableMargin").Return(big.NewInt(1e5))
 			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			lotp.On("ExecuteLiquidation", traderAddress, longOrder, expectedFillAmount).Return(nil)
 
@@ -80,7 +80,7 @@ func TestRunLiquidations(t *testing.T) {
 
 			expectedFillAmount := utils.BigIntMinAbs(longOrder.BaseAssetQuantity, liquidablePositions[0].Size)
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetMinAllowableMargin").Return(big.NewInt(1e5))
 			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			lotp.On("ExecuteLiquidation", traderAddress, longOrder, expectedFillAmount).Return(nil)
 
@@ -106,7 +106,7 @@ func TestRunLiquidations(t *testing.T) {
 			orderMap := map[Market]*Orders{market: {[]Order{longOrder0, longOrder1}, []Order{shortOrder0, shortOrder1}}}
 
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetMinAllowableMargin").Return(big.NewInt(1e5))
 			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			lotp.On("ExecuteLiquidation", traderAddress, orderMap[market].longOrders[0], big.NewInt(5)).Return(nil)
 			lotp.On("ExecuteLiquidation", traderAddress, orderMap[market].longOrders[1], big.NewInt(2)).Return(nil)
@@ -153,7 +153,7 @@ func TestRunLiquidations(t *testing.T) {
 			orderMap := map[Market]*Orders{market: {longOrders, shortOrders}}
 
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetMinAllowableMargin").Return(big.NewInt(1e5))
 			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 			pipeline.runLiquidations(liquidablePositions, orderMap, underlyingPrices, map[common.Address]*big.Int{})
 			assert.Equal(t, longOrders, orderMap[market].longOrders)
@@ -168,7 +168,7 @@ func TestRunLiquidations(t *testing.T) {
 			expectedFillAmount := utils.BigIntMinAbs(shortOrder.BaseAssetQuantity, liquidablePositions[0].Size)
 			lotp.On("ExecuteLiquidation", traderAddress, shortOrder, expectedFillAmount).Return(nil)
 			cs.On("GetAcceptableBoundsForLiquidation", market).Return(liqUpperBound, liqLowerBound)
-			cs.On("getMinAllowableMargin").Return(big.NewInt(1e5))
+			cs.On("GetMinAllowableMargin").Return(big.NewInt(1e5))
 			cs.On("GetTakerFee").Return(big.NewInt(1e5))
 
 			orderMap := map[Market]*Orders{market: {[]Order{longOrder}, []Order{shortOrder}}}

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -364,7 +364,7 @@ func TestGetCancellableOrders(t *testing.T) {
 	inMemoryDatabase := getDatabase()
 	getReservedMargin := func(order Order) *big.Int {
 		notional := big.NewInt(0).Abs(big.NewInt(0).Div(big.NewInt(0).Mul(order.BaseAssetQuantity, order.Price), hu.ONE_E_18))
-		return hu.Div1e6(big.NewInt(0).Mul(notional, inMemoryDatabase.configService.getMinAllowableMargin()))
+		return hu.Div1e6(big.NewInt(0).Mul(notional, inMemoryDatabase.configService.GetMinAllowableMargin()))
 	}
 
 	blockNumber1 := big.NewInt(2)
@@ -418,8 +418,8 @@ func TestGetCancellableOrders(t *testing.T) {
 		OraclePrices:       priceMap,
 		MidPrices:          inMemoryDatabase.GetLastPrices(),
 		ActiveMarkets:      []Market{market},
-		MinAllowableMargin: inMemoryDatabase.configService.getMinAllowableMargin(),
-		MaintenanceMargin:  inMemoryDatabase.configService.getMaintenanceMargin(),
+		MinAllowableMargin: inMemoryDatabase.configService.GetMinAllowableMargin(),
+		MaintenanceMargin:  inMemoryDatabase.configService.GetMaintenanceMargin(),
 		UpgradeVersion:     hu.V2,
 	}
 	marginFraction := calcMarginFraction(_trader, hState)

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -20,6 +20,7 @@ var (
 	// panics are recovered but monitored
 	AllPanicsCounter                         = metrics.NewRegisteredCounter("all_panics", nil)
 	RunMatchingPipelinePanicsCounter         = metrics.NewRegisteredCounter("matching_pipeline_panics", nil)
+	RunSanitaryPipelinePanicsCounter         = metrics.NewRegisteredCounter("sanitary_pipeline_panics", nil)
 	HandleHubbleFeedLogsPanicsCounter        = metrics.NewRegisteredCounter("handle_hubble_feed_logs_panics", nil)
 	HandleChainAcceptedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
 	HandleChainAcceptedEventPanicsCounter    = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -254,12 +254,12 @@ func (mcs *MockConfigService) getMaxLiquidationRatio(market Market) *big.Int {
 	return args.Get(0).(*big.Int)
 }
 
-func (mcs *MockConfigService) getMinAllowableMargin() *big.Int {
+func (mcs *MockConfigService) GetMinAllowableMargin() *big.Int {
 	args := mcs.Called()
 	return args.Get(0).(*big.Int)
 }
 
-func (mcs *MockConfigService) getMaintenanceMargin() *big.Int {
+func (mcs *MockConfigService) GetMaintenanceMargin() *big.Int {
 	args := mcs.Called()
 	return args.Get(0).(*big.Int)
 }

--- a/plugin/evm/orderbook/service.go
+++ b/plugin/evm/orderbook/service.go
@@ -124,8 +124,8 @@ func (api *OrderBookAPI) GetDebugData(ctx context.Context, trader string) GetDeb
 			OraclePrices:       oraclePrices,
 			MidPrices:          midPrices,
 			ActiveMarkets:      markets,
-			MinAllowableMargin: api.configService.getMinAllowableMargin(),
-			MaintenanceMargin:  api.configService.getMaintenanceMargin(),
+			MinAllowableMargin: api.configService.GetMinAllowableMargin(),
+			MaintenanceMargin:  api.configService.GetMaintenanceMargin(),
 		}
 		marginFraction := calcMarginFraction(&trader, hState)
 		availableMargin := getAvailableMargin(&trader, hState)

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -5,6 +5,7 @@ package orderbook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -353,6 +354,7 @@ func (api *TradingAPI) PlaceOrder(order *hu.SignedOrder) (common.Hash, error) {
 		}
 	} else {
 		// @todo P3. Sum of all reduce only orders should not exceed the total position size
+		return orderId, errors.New("reduce only orders via makerbook are not supported yet")
 	}
 
 	// P4. Post only order shouldn't cross the market

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -345,7 +345,7 @@ func (api *TradingAPI) PlaceOrder(order *hu.SignedOrder) (common.Hash, error) {
 	requiredMargin := big.NewInt(0)
 	if !order.ReduceOnly {
 		// P2. Margin is available for non-reduce only orders
-		minAllowableMargin := api.configService.getMinAllowableMargin()
+		minAllowableMargin := api.configService.GetMinAllowableMargin()
 		// even tho order might be matched at a different price, we reserve margin at the price the order was placed at to keep it simple
 		requiredMargin = hu.GetRequiredMargin(order.Price, hu.Abs(order.BaseAssetQuantity), minAllowableMargin, big.NewInt(0))
 		if fields.AvailableMargin.Cmp(requiredMargin) == -1 {

--- a/precompile/contracts/jurorv2/contract.go
+++ b/precompile/contracts/jurorv2/contract.go
@@ -16,7 +16,6 @@ import (
 	_ "embed"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
@@ -155,7 +154,6 @@ func getNotionalPositionAndMargin(accessibleState contract.AccessibleState, call
 
 	// CUSTOM CODE STARTS HERE
 	bibliophile := bibliophile.NewBibliophileClient(accessibleState)
-	log.Info("getNotionalPositionAndMargin", "accessibleState.GetSnowContext().ChainID", accessibleState.GetSnowContext().ChainID.String())
 	output := GetNotionalPositionAndMargin(bibliophile, &inputStruct)
 	packedOutput, err := PackGetNotionalPositionAndMarginOutput(output)
 	if err != nil {
@@ -251,7 +249,6 @@ func validateOrdersAndDetermineFillPrice(accessibleState contract.AccessibleStat
 	}
 
 	// CUSTOM CODE STARTS HERE
-	log.Info("validateOrdersAndDetermineFillPrice", "inputStruct", inputStruct)
 	bibliophile := bibliophile.NewBibliophileClient(accessibleState)
 	output := ValidateOrdersAndDetermineFillPrice(bibliophile, &inputStruct)
 	packedOutput, err := PackValidateOrdersAndDetermineFillPriceOutput(output)


### PR DESCRIPTION
## Why this should be merged
A. Whenever we run the matching engine, we fetch all the values for `hubble state` or `hState`. In this change, we construct that struct once and then cache it for use everywhere. This has the tradeoff that whenever any of these are modified, the nodes will need to be restarted: Collaterals, ActiveMarkets, MinAllowableMargin, MaintenanceMargin, TakerFee. The cached hState can be used to calculate AvailableMargin when placing makerbook orders.

B. Add a ticker for every second that deletes the expired makerbook orders, so rpc nodes don't have to run the entire matching engine.

C. Snapshot every 10 blocks (required for testnet as blocks are produced very slowly)

D. Remove unnecessary logs