### PR TITLE
Makerbook storage and save snapshot to file

### DIFF
--- a/chain.json
+++ b/chain.json
@@ -10,5 +10,7 @@
   "is-validator": true,
   "trading-api-enabled": true,
   "testing-api-enabled": true,
-  "load-from-snapshot-enabled": true
+  "load-from-snapshot-enabled": true,
+  "snapshot-file-path": "/tmp/snapshot",
+  "makerbook-database-path": "/tmp/makerbook"
 }

--- a/network-configs/aylin/chain.json
+++ b/network-configs/aylin/chain.json
@@ -8,5 +8,7 @@
   "priority-regossip-addresses": ["0x06CCAD927e6B1d36E219Cb582Af3185D0705f78F"],
   "validator-private-key-file": "/home/ubuntu/validator.pk",
   "feeRecipient": "<insert address corresponding to private key above>",
-  "is-validator": true
+  "is-validator": true,
+  "snapshot-file-path": "/tmp/snapshot",
+  "makerbook-database-path": "/tmp/makerbook"
 }

--- a/network-configs/aylin/chain_api_node.json
+++ b/network-configs/aylin/chain_api_node.json
@@ -9,5 +9,7 @@
     "coreth-admin-api-enabled": true,
     "eth-apis": ["public-eth","public-eth-filter","net","web3","internal-eth","internal-blockchain","internal-transaction","internal-debug","internal-tx-pool","internal-account","debug-tracer"],
     "trading-api-enabled": true,
-    "testing-api-enabled": true
+    "testing-api-enabled": true,
+    "snapshot-file-path": "/tmp/snapshot",
+    "makerbook-database-path": "/tmp/makerbook"
 }

--- a/network-configs/aylin/chain_archival_node.json
+++ b/network-configs/aylin/chain_archival_node.json
@@ -10,5 +10,7 @@
     "coreth-admin-api-enabled": true,
     "eth-apis": ["public-eth","public-eth-filter","net","web3","internal-public-eth","internal-blockchain","internal-transaction","internal-debug","internal-tx-pool","internal-account","debug-tracer"],
     "trading-api-enabled": true,
-    "testing-api-enabled": true
+    "testing-api-enabled": true,
+    "snapshot-file-path": "/tmp/snapshot",
+    "makerbook-database-path": "/tmp/makerbook"
 }

--- a/network-configs/hubblenet/chain_api_node.json
+++ b/network-configs/hubblenet/chain_api_node.json
@@ -12,5 +12,7 @@
     "admin-api-enabled": true,
     "eth-apis": ["public-eth","public-eth-filter","net","web3","internal-public-eth","internal-blockchain","internal-transaction","internal-debug","internal-tx-pool","internal-account","debug-tracer"],
     "trading-api-enabled": true,
-    "testing-api-enabled": true
+    "testing-api-enabled": true,
+    "snapshot-file-path": "/tmp/snapshot",
+    "makerbook-database-path": "/tmp/makerbook"
 }

--- a/network-configs/hubblenet/chain_archival_node.json
+++ b/network-configs/hubblenet/chain_archival_node.json
@@ -13,5 +13,7 @@
     "admin-api-enabled": true,
     "eth-apis": ["public-eth","public-eth-filter","net","web3","internal-public-eth","internal-blockchain","internal-transaction","internal-debug","internal-tx-pool","internal-account","debug-tracer"],
     "trading-api-enabled": true,
-    "testing-api-enabled": true
+    "testing-api-enabled": true,
+    "snapshot-file-path": "/tmp/snapshot",
+    "makerbook-database-path": "/tmp/makerbook"
 }

--- a/network-configs/hubblenet/chain_validator_1.json
+++ b/network-configs/hubblenet/chain_validator_1.json
@@ -11,5 +11,6 @@
   "continuous-profiler-frequency": "10m",
   "validator-private-key-file": "/var/avalanche/validator.pk",
   "feeRecipient": "0xa5e31FbE901362Cc93b6fdab99DB9741c673a942",
-  "is-validator": true
+  "is-validator": true,
+  "snapshot-file-path": "/tmp/snapshot"
 }

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -63,8 +63,8 @@ const (
 	defaultIsValidator             = false
 	defaultTradingAPIEnabled       = false
 	defaultLoadFromSnapshotEnabled = true
-	defaultSnapshotFilePath        = "/home/ubuntu/.avalanche-cli/snapshot/evm.snapshot"
-	defaultMakerbookDatabasePath   = "/home/ubuntu/.avalanche-cli/evm/makerbook.db"
+	defaultSnapshotFilePath        = "/tmp/snapshot"
+	defaultMakerbookDatabasePath   = "/tmp/makerbook"
 )
 
 var (

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -63,6 +63,8 @@ const (
 	defaultIsValidator             = false
 	defaultTradingAPIEnabled       = false
 	defaultLoadFromSnapshotEnabled = true
+	defaultSnapshotFilePath        = "/home/ubuntu/.avalanche-cli/snapshot/evm.snapshot"
+	defaultMakerbookDatabasePath   = "/home/ubuntu/.avalanche-cli/evm/makerbook.db"
 )
 
 var (
@@ -242,6 +244,12 @@ type Config struct {
 
 	// LoadFromSnapshotEnabled = true if the node should load the memory db from a snapshot
 	LoadFromSnapshotEnabled bool `json:"load-from-snapshot-enabled"`
+
+	// SnapshotFilePath is the path to the file which saves the latest snapshot bytes
+	SnapshotFilePath string `json:"snapshot-file-path"`
+
+	// MakerbookDatabasePath is the path to the file which saves the makerbook orders
+	MakerbookDatabasePath string `json:"makerbook-database-path"`
 }
 
 // EthAPIs returns an array of strings representing the Eth APIs that should be enabled
@@ -306,6 +314,8 @@ func (c *Config) SetDefaults() {
 	c.IsValidator = defaultIsValidator
 	c.TradingAPIEnabled = defaultTradingAPIEnabled
 	c.LoadFromSnapshotEnabled = defaultLoadFromSnapshotEnabled
+	c.SnapshotFilePath = defaultSnapshotFilePath
+	c.MakerbookDatabasePath = defaultMakerbookDatabasePath
 }
 
 func (d *Duration) UnmarshalJSON(data []byte) (err error) {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -195,7 +195,7 @@ func (lop *limitOrderProcesser) GetOrderBookAPI() *orderbook.OrderBookAPI {
 
 func (lop *limitOrderProcesser) GetTradingAPI() *orderbook.TradingAPI {
 	if lop.tradingAPI == nil {
-		lop.tradingAPI = orderbook.NewTradingAPI(lop.memoryDb, lop.backend, lop.configService)
+		lop.tradingAPI = orderbook.NewTradingAPI(lop.memoryDb, lop.backend, lop.configService, lop.shutdownChan, lop.shutdownWg)
 	}
 	return lop.tradingAPI
 }

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -349,7 +349,7 @@ func (lop *limitOrderProcesser) runMatchingTimer() {
 
 func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromFile() (acceptedBlockNumber uint64, err error) {
 	if lop.snapshotFilePath == "" {
-		return acceptedBlockNumber, nil
+		return acceptedBlockNumber, fmt.Errorf("snapshot file path not set")
 	}
 
 	memorySnapshotBytes, err := os.ReadFile(lop.snapshotFilePath)

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -473,12 +473,6 @@ func (lop *limitOrderProcesser) saveMemoryDBSnapshot(acceptedBlockNumber *big.In
 	}
 
 	snapshotBytes := buf.Bytes()
-
-	err = lop.hubbleDB.Put([]byte(memoryDBSnapshotKey), snapshotBytes)
-	if err != nil {
-		return fmt.Errorf("Error in saving to DB: err=%v", err)
-	}
-
 	// write to snapshot file
 	if lop.snapshotFilePath != "" {
 		err = os.WriteFile(lop.snapshotFilePath, snapshotBytes, 0644)

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -359,70 +359,70 @@ func (lop *limitOrderProcesser) loadMemoryDBSnapshot() (acceptedBlockNumber uint
 	return acceptedBlockNumber, err
 }
 
-func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromHubbleDB() (acceptedBlockNumber uint64, err error) {
+func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromHubbleDB() (uint64, error) {
 	snapshotFound, err := lop.hubbleDB.Has([]byte(memoryDBSnapshotKey))
 	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in checking snapshot in hubbleDB: err=%v", err)
+		return 0, fmt.Errorf("Error in checking snapshot in hubbleDB: err=%v", err)
 	}
 
 	if !snapshotFound {
-		return acceptedBlockNumber, nil
+		return 0, nil
 	}
 
 	memorySnapshotBytes, err := lop.hubbleDB.Get([]byte(memoryDBSnapshotKey))
 	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in fetching snapshot from hubbleDB; err=%v", err)
+		return 0, fmt.Errorf("Error in fetching snapshot from hubbleDB; err=%v", err)
 	}
 
 	buf := bytes.NewBuffer(memorySnapshotBytes)
 	var snapshot orderbook.Snapshot
 	err = gob.NewDecoder(buf).Decode(&snapshot)
 	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in snapshot parsing from hubbleDB; err=%v", err)
+		return 0, fmt.Errorf("Error in snapshot parsing from hubbleDB; err=%v", err)
 	}
 
 	if snapshot.AcceptedBlockNumber != nil && snapshot.AcceptedBlockNumber.Uint64() > 0 {
 		err = lop.memoryDb.LoadFromSnapshot(snapshot)
 		if err != nil {
-			return acceptedBlockNumber, fmt.Errorf("Error in loading snapshot from hubbleDB: err=%v", err)
+			return 0, fmt.Errorf("Error in loading snapshot from hubbleDB: err=%v", err)
 		} else {
 			log.Info("memory DB snapshot loaded from hubbleDB", "acceptedBlockNumber", snapshot.AcceptedBlockNumber)
 		}
 
 		return snapshot.AcceptedBlockNumber.Uint64(), nil
 	} else {
-		return acceptedBlockNumber, nil
+		return 0, nil
 	}
 }
 
-func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromFile() (acceptedBlockNumber uint64, err error) {
+func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromFile() (uint64, error) {
 	if lop.snapshotFilePath == "" {
-		return acceptedBlockNumber, fmt.Errorf("snapshot file path not set")
+		return 0, fmt.Errorf("snapshot file path not set")
 	}
 
 	memorySnapshotBytes, err := os.ReadFile(lop.snapshotFilePath)
 	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in reading snapshot file: err=%v", err)
+		return 0, fmt.Errorf("Error in reading snapshot file: err=%v", err)
 	}
 
 	buf := bytes.NewBuffer(memorySnapshotBytes)
 	var snapshot orderbook.Snapshot
 	err = gob.NewDecoder(buf).Decode(&snapshot)
 	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in snapshot parsing from file; err=%v", err)
+		return 0, fmt.Errorf("Error in snapshot parsing from file; err=%v", err)
 	}
 
 	if snapshot.AcceptedBlockNumber != nil && snapshot.AcceptedBlockNumber.Uint64() > 0 {
 		err = lop.memoryDb.LoadFromSnapshot(snapshot)
 		if err != nil {
-			return acceptedBlockNumber, fmt.Errorf("Error in loading snapshot from file: err=%v", err)
+			return 0, fmt.Errorf("Error in loading snapshot from file: err=%v", err)
 		} else {
 			log.Info("memory DB snapshot loaded from file", "acceptedBlockNumber", snapshot.AcceptedBlockNumber)
 		}
 
 		return snapshot.AcceptedBlockNumber.Uint64(), nil
 	} else {
-		return acceptedBlockNumber, nil
+		return 0, nil
 	}
 }
 

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -369,7 +369,7 @@ func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromFile() (acceptedBlockNum
 		if err != nil {
 			return acceptedBlockNumber, fmt.Errorf("Error in loading snapshot from file: err=%v", err)
 		} else {
-			log.Info("memory DB snapshot loaded from file", "acceptedBlockNumber", acceptedBlockNumber)
+			log.Info("memory DB snapshot loaded from file", "acceptedBlockNumber", snapshot.AcceptedBlockNumber)
 		}
 
 		return snapshot.AcceptedBlockNumber.Uint64(), nil

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -386,7 +386,7 @@ func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromHubbleDB() (acceptedBloc
 		if err != nil {
 			return acceptedBlockNumber, fmt.Errorf("Error in loading snapshot from hubbleDB: err=%v", err)
 		} else {
-			log.Info("ListenAndProcessTransactions - memory DB snapshot loaded from hubbleDB", "acceptedBlockNumber", acceptedBlockNumber)
+			log.Info("memory DB snapshot loaded from hubbleDB", "acceptedBlockNumber", snapshot.AcceptedBlockNumber)
 		}
 
 		return snapshot.AcceptedBlockNumber.Uint64(), nil

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -22,14 +22,12 @@ import (
 	hu "github.com/ava-labs/subnet-evm/plugin/evm/orderbook/hubbleutils"
 	"github.com/ava-labs/subnet-evm/utils"
 
-	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ethereum/go-ethereum/log"
 )
 
 const (
-	memoryDBSnapshotKey string = "memoryDBSnapshot"
-	snapshotInterval    uint64 = 10 // save snapshot every 1000 blocks
+	snapshotInterval uint64 = 10 // save snapshot every 1000 blocks
 )
 
 type LimitOrderProcesser interface {
@@ -52,7 +50,6 @@ type limitOrderProcesser struct {
 	contractEventProcessor   *orderbook.ContractEventsProcessor
 	matchingPipeline         *orderbook.MatchingPipeline
 	filterAPI                *filters.FilterAPI
-	hubbleDB                 database.Database
 	configService            orderbook.IConfigService
 	blockBuilder             *blockBuilder
 	isValidator              bool
@@ -63,7 +60,7 @@ type limitOrderProcesser struct {
 	tradingAPI               *orderbook.TradingAPI
 }
 
-func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, hubbleDB database.Database, validatorPrivateKey string, config Config) LimitOrderProcesser {
+func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownChan <-chan struct{}, shutdownWg *sync.WaitGroup, backend *eth.EthAPIBackend, blockChain *core.BlockChain, validatorPrivateKey string, config Config) LimitOrderProcesser {
 	log.Info("**** NewLimitOrderProcesser")
 	configService := orderbook.NewConfigService(blockChain)
 	memoryDb := orderbook.NewInMemoryDatabase(configService)
@@ -101,7 +98,6 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownCh
 		shutdownWg:              shutdownWg,
 		backend:                 backend,
 		memoryDb:                memoryDb,
-		hubbleDB:                hubbleDB,
 		blockChain:              blockChain,
 		limitOrderTxProcessor:   lotp,
 		contractEventProcessor:  contractEventProcessor,
@@ -125,7 +121,7 @@ func (lop *limitOrderProcesser) ListenAndProcessTransactions(blockBuilder *block
 
 		if lop.loadFromSnapshotEnabled {
 			// first load the last snapshot containing finalised data till block x and query the logs of [x+1, latest]
-			acceptedBlockNumber, err := lop.loadMemoryDBSnapshot()
+			acceptedBlockNumber, err := lop.loadMemoryDBSnapshotFromFile()
 			if err != nil {
 				log.Error("ListenAndProcessTransactions - error in loading snapshot", "err", err)
 			} else {
@@ -201,7 +197,7 @@ func (lop *limitOrderProcesser) GetTradingAPI() *orderbook.TradingAPI {
 }
 
 func (lop *limitOrderProcesser) GetTestingAPI() *orderbook.TestingAPI {
-	return orderbook.NewTestingAPI(lop.memoryDb, lop.backend, lop.configService, lop.hubbleDB)
+	return orderbook.NewTestingAPI(lop.memoryDb, lop.backend, lop.configService, lop.snapshotFilePath)
 }
 
 func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
@@ -268,8 +264,9 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 						log.Info("Saving memory DB snapshot", "snapshotBlockNumber", snapshotBlockNumber, "current blockNumber", blockNumber, "blockNumberFloor", blockNumberFloor)
 						snapshotBlock := lop.blockChain.GetBlockByNumber(snapshotBlockNumber)
 						lop.memoryDb.Accept(snapshotBlockNumber, snapshotBlock.Timestamp())
-						err := lop.saveMemoryDBSnapshot(big.NewInt(int64(snapshotBlockNumber)))
+						err := lop.saveMemoryDBSnapshotToFile(big.NewInt(int64(snapshotBlockNumber)))
 						if err != nil {
+							orderbook.SnapshotWriteFailuresCounter.Inc(1)
 							log.Error("Error in saving memory DB snapshot", "err", err, "snapshotBlockNumber", snapshotBlockNumber, "current blockNumber", blockNumber, "blockNumberFloor", blockNumberFloor)
 						}
 					}
@@ -350,51 +347,6 @@ func (lop *limitOrderProcesser) runMatchingTimer() {
 	}, orderbook.RunMatchingPipelinePanicMessage, orderbook.RunMatchingPipelinePanicsCounter)
 }
 
-func (lop *limitOrderProcesser) loadMemoryDBSnapshot() (acceptedBlockNumber uint64, err error) {
-	// logging is done in the respective functions
-	acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromHubbleDB()
-	if err != nil || acceptedBlockNumber == 0 {
-		acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromFile()
-	}
-	return acceptedBlockNumber, err
-}
-
-func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromHubbleDB() (acceptedBlockNumber uint64, err error) {
-	snapshotFound, err := lop.hubbleDB.Has([]byte(memoryDBSnapshotKey))
-	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in checking snapshot in hubbleDB: err=%v", err)
-	}
-
-	if !snapshotFound {
-		return acceptedBlockNumber, nil
-	}
-
-	memorySnapshotBytes, err := lop.hubbleDB.Get([]byte(memoryDBSnapshotKey))
-	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in fetching snapshot from hubbleDB; err=%v", err)
-	}
-
-	buf := bytes.NewBuffer(memorySnapshotBytes)
-	var snapshot orderbook.Snapshot
-	err = gob.NewDecoder(buf).Decode(&snapshot)
-	if err != nil {
-		return acceptedBlockNumber, fmt.Errorf("Error in snapshot parsing from hubbleDB; err=%v", err)
-	}
-
-	if snapshot.AcceptedBlockNumber != nil && snapshot.AcceptedBlockNumber.Uint64() > 0 {
-		err = lop.memoryDb.LoadFromSnapshot(snapshot)
-		if err != nil {
-			return acceptedBlockNumber, fmt.Errorf("Error in loading snapshot from hubbleDB: err=%v", err)
-		} else {
-			log.Info("ListenAndProcessTransactions - memory DB snapshot loaded from hubbleDB", "acceptedBlockNumber", acceptedBlockNumber)
-		}
-
-		return snapshot.AcceptedBlockNumber.Uint64(), nil
-	} else {
-		return acceptedBlockNumber, nil
-	}
-}
-
 func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromFile() (acceptedBlockNumber uint64, err error) {
 	if lop.snapshotFilePath == "" {
 		return acceptedBlockNumber, nil
@@ -417,7 +369,7 @@ func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromFile() (acceptedBlockNum
 		if err != nil {
 			return acceptedBlockNumber, fmt.Errorf("Error in loading snapshot from file: err=%v", err)
 		} else {
-			log.Info("ListenAndProcessTransactions - memory DB snapshot loaded from file", "acceptedBlockNumber", acceptedBlockNumber)
+			log.Info("memory DB snapshot loaded from file", "acceptedBlockNumber", acceptedBlockNumber)
 		}
 
 		return snapshot.AcceptedBlockNumber.Uint64(), nil
@@ -427,13 +379,16 @@ func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromFile() (acceptedBlockNum
 }
 
 // assumes that memory DB lock is held
-func (lop *limitOrderProcesser) saveMemoryDBSnapshot(acceptedBlockNumber *big.Int) error {
+func (lop *limitOrderProcesser) saveMemoryDBSnapshotToFile(acceptedBlockNumber *big.Int) error {
+	if lop.snapshotFilePath == "" {
+		return fmt.Errorf("snapshot file path not set")
+	}
 	start := time.Now()
 	currentHeadBlock := lop.blockChain.CurrentBlock()
 
 	memoryDBCopy, err := lop.memoryDb.GetOrderBookDataCopy()
 	if err != nil {
-		return fmt.Errorf("Error in getting memory DB copy: err=%v", err)
+		return fmt.Errorf("error in getting memory DB copy: err=%v", err)
 	}
 	if currentHeadBlock.Number.Cmp(acceptedBlockNumber) == 1 {
 		// if current head is ahead of the accepted block, then certain events(OrderBook)
@@ -474,17 +429,10 @@ func (lop *limitOrderProcesser) saveMemoryDBSnapshot(acceptedBlockNumber *big.In
 
 	snapshotBytes := buf.Bytes()
 
-	err = lop.hubbleDB.Put([]byte(memoryDBSnapshotKey), snapshotBytes)
-	if err != nil {
-		return fmt.Errorf("Error in saving to DB: err=%v", err)
-	}
-
 	// write to snapshot file
-	if lop.snapshotFilePath != "" {
-		err = os.WriteFile(lop.snapshotFilePath, snapshotBytes, 0644)
-		if err != nil {
-			return fmt.Errorf("Error in writing to snapshot file: err=%v", err)
-		}
+	err = os.WriteFile(lop.snapshotFilePath, snapshotBytes, 0644)
+	if err != nil {
+		return fmt.Errorf("Error in writing to snapshot file: err=%v", err)
 	}
 
 	lop.snapshotSavedBlockNumber = acceptedBlockNumber.Uint64()

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -431,6 +431,10 @@ func (lop *limitOrderProcesser) saveMemoryDBSnapshot(acceptedBlockNumber *big.In
 	start := time.Now()
 	currentHeadBlock := lop.blockChain.CurrentBlock()
 
+	if lop.snapshotFilePath == "" {
+		return fmt.Errorf("snapshot file path not set")
+	}
+
 	memoryDBCopy, err := lop.memoryDb.GetOrderBookDataCopy()
 	if err != nil {
 		return fmt.Errorf("Error in getting memory DB copy: err=%v", err)
@@ -474,11 +478,9 @@ func (lop *limitOrderProcesser) saveMemoryDBSnapshot(acceptedBlockNumber *big.In
 
 	snapshotBytes := buf.Bytes()
 	// write to snapshot file
-	if lop.snapshotFilePath != "" {
-		err = os.WriteFile(lop.snapshotFilePath, snapshotBytes, 0644)
-		if err != nil {
-			return fmt.Errorf("Error in writing to snapshot file: err=%v", err)
-		}
+	err = os.WriteFile(lop.snapshotFilePath, snapshotBytes, 0644)
+	if err != nil {
+		return fmt.Errorf("Error in writing to snapshot file: err=%v", err)
 	}
 
 	lop.snapshotSavedBlockNumber = acceptedBlockNumber.Uint64()

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -270,6 +270,7 @@ func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {
 						lop.memoryDb.Accept(snapshotBlockNumber, snapshotBlock.Timestamp())
 						err := lop.saveMemoryDBSnapshot(big.NewInt(int64(snapshotBlockNumber)))
 						if err != nil {
+							orderbook.SnapshotWriteFailuresCounter.Inc(1)
 							log.Error("Error in saving memory DB snapshot", "err", err, "snapshotBlockNumber", snapshotBlockNumber, "current blockNumber", blockNumber, "blockNumberFloor", blockNumberFloor)
 						}
 					}
@@ -351,7 +352,6 @@ func (lop *limitOrderProcesser) runMatchingTimer() {
 }
 
 func (lop *limitOrderProcesser) loadMemoryDBSnapshot() (acceptedBlockNumber uint64, err error) {
-	// logging is done in the respective functions
 	acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromFile()
 	if err != nil || acceptedBlockNumber == 0 {
 		acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromHubbleDB()

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -352,9 +352,9 @@ func (lop *limitOrderProcesser) runMatchingTimer() {
 
 func (lop *limitOrderProcesser) loadMemoryDBSnapshot() (acceptedBlockNumber uint64, err error) {
 	// logging is done in the respective functions
-	acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromHubbleDB()
+	acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromFile()
 	if err != nil || acceptedBlockNumber == 0 {
-		acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromFile()
+		acceptedBlockNumber, err = lop.loadMemoryDBSnapshotFromHubbleDB()
 	}
 	return acceptedBlockNumber, err
 }

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -387,9 +387,8 @@ func (lop *limitOrderProcesser) loadMemoryDBSnapshotFromHubbleDB() (uint64, erro
 			return 0, fmt.Errorf("Error in loading snapshot from hubbleDB: err=%v", err)
 		} else {
 			log.Info("memory DB snapshot loaded from hubbleDB", "acceptedBlockNumber", snapshot.AcceptedBlockNumber)
+			return snapshot.AcceptedBlockNumber.Uint64(), nil
 		}
-
-		return snapshot.AcceptedBlockNumber.Uint64(), nil
 	} else {
 		return 0, nil
 	}

--- a/plugin/evm/orderbook/errors.go
+++ b/plugin/evm/orderbook/errors.go
@@ -1,9 +1,10 @@
 package orderbook
 
 const (
-	HandleChainAcceptedEventPanicMessage = "panic while processing chainAcceptedEvent"
-	HandleChainAcceptedLogsPanicMessage  = "panic while processing chainAcceptedLogs"
-	HandleHubbleFeedLogsPanicMessage     = "panic while processing hubbleFeedLogs"
-	RunMatchingPipelinePanicMessage      = "panic while running matching pipeline"
-	RunSanitaryPipelinePanicMessage      = "panic while running sanitary pipeline"
+	HandleChainAcceptedEventPanicMessage  = "panic while processing chainAcceptedEvent"
+	HandleChainAcceptedLogsPanicMessage   = "panic while processing chainAcceptedLogs"
+	HandleHubbleFeedLogsPanicMessage      = "panic while processing hubbleFeedLogs"
+	RunMatchingPipelinePanicMessage       = "panic while running matching pipeline"
+	RunSanitaryPipelinePanicMessage       = "panic while running sanitary pipeline"
+	MakerBookFileWriteChannelPanicMessage = "panic while sending to makerbook file write channel"
 )

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -42,7 +42,4 @@ var (
 
 	// makerbook write failures
 	makerBookWriteFailuresCounter = metrics.NewRegisteredCounter("makerbook_write_failures", nil)
-
-	// snapshot write failures
-	SnapshotWriteFailuresCounter = metrics.NewRegisteredCounter("snapshot_write_failures", nil)
 )

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -27,6 +27,7 @@ var (
 	HandleMatchingPipelineTimerPanicsCounter = metrics.NewRegisteredCounter("handle_matching_pipeline_timer_panics", nil)
 	RPCPanicsCounter                         = metrics.NewRegisteredCounter("rpc_panic", nil)
 	AwaitSignedOrdersGossipPanicsCounter     = metrics.NewRegisteredCounter("await_signed_orders_gossip_panics", nil)
+	MakerbookFileWriteChannelPanicsCounter   = metrics.NewRegisteredCounter("makerbook_file_write_channel_panics", nil)
 
 	BuildBlockFailedWithLowBlockGasCounter = metrics.NewRegisteredCounter("build_block_failed_low_block_gas", nil)
 

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -42,4 +42,7 @@ var (
 
 	// makerbook write failures
 	makerBookWriteFailuresCounter = metrics.NewRegisteredCounter("makerbook_write_failures", nil)
+
+	// snapshot write failures
+	SnapshotWriteFailuresCounter = metrics.NewRegisteredCounter("snapshot_write_failures", nil)
 )

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -39,4 +39,7 @@ var (
 	// unquenched liquidations
 	unquenchedLiquidationsCounter = metrics.NewRegisteredCounter("unquenched_liquidations", nil)
 	placeSignedOrderCounter       = metrics.NewRegisteredCounter("place_signed_order", nil)
+
+	// makerbook write failures
+	makerBookWriteFailuresCounter = metrics.NewRegisteredCounter("makerbook_write_failures", nil)
 )

--- a/plugin/evm/orderbook/testing_apis.go
+++ b/plugin/evm/orderbook/testing_apis.go
@@ -9,8 +9,8 @@ import (
 	"encoding/gob"
 	"fmt"
 	"math/big"
-	"os"
 
+	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/subnet-evm/eth"
 	"github.com/ava-labs/subnet-evm/precompile/contracts/bibliophile"
 	"github.com/ava-labs/subnet-evm/rpc"
@@ -18,18 +18,18 @@ import (
 )
 
 type TestingAPI struct {
-	db               LimitOrderDatabase
-	backend          *eth.EthAPIBackend
-	configService    IConfigService
-	snapshotFilePath string
+	db            LimitOrderDatabase
+	backend       *eth.EthAPIBackend
+	configService IConfigService
+	hubbleDB      database.Database
 }
 
-func NewTestingAPI(database LimitOrderDatabase, backend *eth.EthAPIBackend, configService IConfigService, snapshotFilePath string) *TestingAPI {
+func NewTestingAPI(database LimitOrderDatabase, backend *eth.EthAPIBackend, configService IConfigService, hubbleDB database.Database) *TestingAPI {
 	return &TestingAPI{
-		db:               database,
-		backend:          backend,
-		configService:    configService,
-		snapshotFilePath: snapshotFilePath,
+		db:            database,
+		backend:       backend,
+		configService: configService,
+		hubbleDB:      hubbleDB,
 	}
 }
 
@@ -60,16 +60,16 @@ func (api *TestingAPI) GetOrderBookVars(ctx context.Context, traderAddress strin
 
 func (api *TestingAPI) GetSnapshot(ctx context.Context) (Snapshot, error) {
 	var snapshot Snapshot
-
-	memorySnapshotBytes, err := os.ReadFile(api.snapshotFilePath)
+	memoryDBSnapshotKey := "memoryDBSnapshot"
+	memorySnapshotBytes, err := api.hubbleDB.Get([]byte(memoryDBSnapshotKey))
 	if err != nil {
-		return snapshot, fmt.Errorf("error in fetching snapshot from hubbleDB; err=%v", err)
+		return snapshot, fmt.Errorf("Error in fetching snapshot from hubbleDB; err=%v", err)
 	}
 
 	buf := bytes.NewBuffer(memorySnapshotBytes)
 	err = gob.NewDecoder(buf).Decode(&snapshot)
 	if err != nil {
-		return snapshot, fmt.Errorf("error in snapshot parsing; err=%v", err)
+		return snapshot, fmt.Errorf("Error in snapshot parsing; err=%v", err)
 	}
 
 	return snapshot, nil

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -23,7 +23,7 @@ import (
 
 var traderFeed event.Feed
 var marketFeed event.Feed
-var MakerbookDatabaseFile = ""
+var MakerbookDatabaseFile string
 
 type TradingAPI struct {
 	db            LimitOrderDatabase

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -23,7 +23,7 @@ import (
 
 var traderFeed event.Feed
 var marketFeed event.Feed
-var SignedOrderDatabaseFile = ""
+var MakerbookDatabaseFile = ""
 
 type TradingAPI struct {
 	db            LimitOrderDatabase
@@ -397,7 +397,7 @@ func (api *TradingAPI) PlaceOrder(order *hu.SignedOrder) (common.Hash, error) {
 	placeSignedOrderCounter.Inc(1)
 	api.db.AddSignedOrder(signedOrder, requiredMargin)
 
-	if len(SignedOrderDatabaseFile) > 0 {
+	if len(MakerbookDatabaseFile) > 0 {
 		go writeOrderToFile(order, orderId)
 	}
 
@@ -457,7 +457,7 @@ func writeOrderToFile(order *hu.SignedOrder, orderId common.Hash) {
 		makerBookWriteFailuresCounter.Inc(1)
 		return
 	}
-	err = utils.AppendToFile(SignedOrderDatabaseFile, jsonDoc)
+	err = utils.AppendToFile(MakerbookDatabaseFile, jsonDoc)
 	if err != nil {
 		log.Error("writeOrderToFile: failed to write order to file", "err", err)
 		makerBookWriteFailuresCounter.Inc(1)

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -122,13 +122,9 @@ var mapStatus = map[Status]string{
 }
 
 func (api *TradingAPI) GetTradingOrderBookDepth(ctx context.Context, market int8) TradingOrderBookDepthResponse {
-	response := TradingOrderBookDepthResponse{
-		Asks: [][]string{},
-		Bids: [][]string{},
-	}
 	depth := getDepthForMarket(api.db, Market(market))
 
-	response = transformMarketDepth(depth)
+	response := transformMarketDepth(depth)
 	response.T = time.Now().Unix()
 
 	return response

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -399,6 +399,7 @@ func (api *TradingAPI) PlaceOrder(order *hu.SignedOrder) (common.Hash, error) {
 
 	// validations passed, add to db
 	signedOrder := &Order{
+		Id:                      orderId,
 		Market:                  Market(order.AmmIndex.Int64()),
 		PositionType:            getPositionTypeBasedOnBaseAssetQuantity(order.BaseAssetQuantity),
 		Trader:                  trader,

--- a/plugin/evm/orderbook/trading_apis.go
+++ b/plugin/evm/orderbook/trading_apis.go
@@ -399,9 +399,19 @@ func (api *TradingAPI) PlaceOrder(order *hu.SignedOrder) (common.Hash, error) {
 
 	// validations passed, add to db
 	signedOrder := &Order{
+		Market:                  Market(order.AmmIndex.Int64()),
+		PositionType:            getPositionTypeBasedOnBaseAssetQuantity(order.BaseAssetQuantity),
+		Trader:                  trader,
+		BaseAssetQuantity:       order.BaseAssetQuantity,
 		FilledBaseAssetQuantity: big.NewInt(0),
+		Price:                   order.Price,
+		Salt:                    order.Salt,
+		ReduceOnly:              order.ReduceOnly,
 		BlockNumber:             big.NewInt(0),
+		RawOrder:                order,
+		OrderType:               Signed,
 	}
+
 	placeSignedOrderCounter.Inc(1)
 	api.db.AddSignedOrder(signedOrder, requiredMargin)
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1011,7 +1011,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	if err := handler.RegisterName("order", NewOrderAPI(vm.limitOrderProcesser.GetTradingAPI(), vm)); err != nil {
 		return nil, err
 	}
-	orderbook.SignedOrderDatabaseFile = vm.config.MakerbookDatabasePath
+	orderbook.MakerbookDatabaseFile = vm.config.MakerbookDatabasePath
 
 	if err := handler.RegisterName("orderbook", vm.limitOrderProcesser.GetOrderBookAPI()); err != nil {
 		return nil, err

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1011,6 +1011,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	if err := handler.RegisterName("order", NewOrderAPI(vm.limitOrderProcesser.GetTradingAPI(), vm)); err != nil {
 		return nil, err
 	}
+	orderbook.SignedOrderDatabaseFile = vm.config.MakerbookDatabasePath
 
 	if err := handler.RegisterName("orderbook", vm.limitOrderProcesser.GetOrderBookAPI()); err != nil {
 		return nil, err

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1185,6 +1185,7 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 		&vm.shutdownWg,
 		vm.eth.APIBackend,
 		vm.blockChain,
+		vm.hubbleDB,
 		validatorPrivateKey,
 		vm.config,
 	)

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1185,7 +1185,6 @@ func (vm *VM) NewLimitOrderProcesser() LimitOrderProcesser {
 		&vm.shutdownWg,
 		vm.eth.APIBackend,
 		vm.blockChain,
-		vm.hubbleDB,
 		validatorPrivateKey,
 		vm.config,
 	)

--- a/utils/file.go
+++ b/utils/file.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"os"
+)
+
+func AppendToFile(file string, data []byte) error {
+	f, err := os.OpenFile(file, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	// Add a newline to the beginning of the data
+	data = append([]byte("\n"), data...)
+	if _, err := f.Write(data); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Why this should be merged
- Store snapshot only to file, and not to hubbleDB
- Load snapshot from file first, if not found then load from hubbleDB
- Store maker book orders to a file, each in a new line. The format is same as orders in the indexer database
- Update relevant configs

## How this was tested
on local and aylin

## TODO
Need to update file paths for mainnet configs as per the docker and kubernetes filesystems