### PR TITLE
Fix panic in saving snapshot

### DIFF
--- a/plugin/evm/orderbook/errors.go
+++ b/plugin/evm/orderbook/errors.go
@@ -7,4 +7,5 @@ const (
 	RunMatchingPipelinePanicMessage       = "panic while running matching pipeline"
 	RunSanitaryPipelinePanicMessage       = "panic while running sanitary pipeline"
 	MakerBookFileWriteChannelPanicMessage = "panic while sending to makerbook file write channel"
+	SaveSnapshotPanicMessage              = "panic while saving snapshot"
 )

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -28,7 +28,7 @@ type InMemoryDatabase struct {
 	CumulativePremiumFraction map[Market]*big.Int        `json:"cumulative_last_premium_fraction"`
 	NextSamplePITime          uint64                     `json:"next_sample_pi_time"`
 	SamplePIAttemptedTime     uint64                     `json:"sample_pi_attempted_time"`
-	configService             IConfigService
+	configService             IConfigService             `json:"-"`
 }
 
 func NewInMemoryDatabase(configService IConfigService) *InMemoryDatabase {
@@ -617,7 +617,7 @@ func (db *InMemoryDatabase) UpdateFilledBaseAssetQuantity(quantity *big.Int, ord
 
 	// only update margin if the order is not reduce-only
 	if order.OrderType == Signed && !order.ReduceOnly {
-		minAllowableMargin := db.configService.GetMinAllowableMargin()
+		minAllowableMargin := hu.GetHubbleState().MinAllowableMargin
 		requiredMargin := hu.GetRequiredMargin(order.Price, quantity, minAllowableMargin, big.NewInt(0))
 		db.updateVirtualReservedMargin(order.Trader, hu.Neg(requiredMargin))
 
@@ -1198,6 +1198,7 @@ func (db *InMemoryDatabase) GetOrderBookDataCopy() (*InMemoryDatabase, error) {
 	}
 
 	memoryDBCopy.mu = &sync.RWMutex{}
+	memoryDBCopy.configService = db.configService
 	return memoryDBCopy, nil
 }
 

--- a/plugin/evm/orderbook/metrics.go
+++ b/plugin/evm/orderbook/metrics.go
@@ -23,6 +23,7 @@ var (
 	RunSanitaryPipelinePanicsCounter         = metrics.NewRegisteredCounter("sanitary_pipeline_panics", nil)
 	HandleHubbleFeedLogsPanicsCounter        = metrics.NewRegisteredCounter("handle_hubble_feed_logs_panics", nil)
 	HandleChainAcceptedLogsPanicsCounter     = metrics.NewRegisteredCounter("handle_chain_accepted_logs_panics", nil)
+	SaveSnapshotPanicsCounter                = metrics.NewRegisteredCounter("save_snapshot_panics", nil)
 	HandleChainAcceptedEventPanicsCounter    = metrics.NewRegisteredCounter("handle_chain_accepted_event_panics", nil)
 	HandleMatchingPipelineTimerPanicsCounter = metrics.NewRegisteredCounter("handle_matching_pipeline_timer_panics", nil)
 	RPCPanicsCounter                         = metrics.NewRegisteredCounter("rpc_panic", nil)


### PR DESCRIPTION
## Why this should be merged
- Set configService in memory db copy
- Use HubbleState to get minAllowableMargin
- Save snapshot in a separate panic-recover wrapper

## How this works

## How this was tested
- on local
