### PR TITLE
allow grace period for market orders to be filled

### DIFF
--- a/plugin/evm/gossiper_orders.go
+++ b/plugin/evm/gossiper_orders.go
@@ -163,6 +163,7 @@ func (h *GossipHandler) HandleSignedOrders(nodeID ids.NodeID, msg message.Signed
 			h.stats.IncSignedOrdersGossipReceivedNew()
 			ordersToGossip = append(ordersToGossip, order)
 			if shouldTriggerMatching {
+				log.Info("received new match-able signed order, triggering matching pipeline...")
 				h.vm.limitOrderProcesser.RunMatchingPipeline()
 			}
 		} else if err == hu.ErrOrderAlreadyExists {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -37,6 +37,7 @@ type LimitOrderProcesser interface {
 	GetOrderBookAPI() *orderbook.OrderBookAPI
 	GetTestingAPI() *orderbook.TestingAPI
 	GetTradingAPI() *orderbook.TradingAPI
+	RunMatchingPipeline()
 }
 
 type limitOrderProcesser struct {
@@ -348,6 +349,7 @@ func (lop *limitOrderProcesser) runMatchingTimer() {
 
 			case <-lop.shutdownChan:
 				lop.matchingPipeline.MatchingTicker.Stop()
+				lop.matchingPipeline.SanitaryTicker.Stop()
 				return
 			}
 		}

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -72,7 +72,8 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownCh
 	contractEventProcessor := orderbook.NewContractEventsProcessor(memoryDb, signedObAddy)
 
 	matchingPipeline := orderbook.NewMatchingPipeline(memoryDb, lotp, configService)
-	// if any of the following values are changed, the nodes will need to be restarted
+	// if any of the following values are changed, the nodes will need to be restarted.
+	// This is also true for local testing. once contracts are deployed it's mandatory to restart the nodes
 	hState := &hu.HubbleState{
 		Assets:             matchingPipeline.GetCollaterals(),
 		ActiveMarkets:      matchingPipeline.GetActiveMarkets(),

--- a/plugin/evm/order_api.go
+++ b/plugin/evm/order_api.go
@@ -60,7 +60,7 @@ func (api *OrderAPI) PlaceSignedOrders(ctx context.Context, input string) (Place
 			continue
 		}
 
-		orderId, err := api.tradingAPI.PlaceOrder(order)
+		orderId, _, err := api.tradingAPI.PlaceOrder(order)
 		orderResponse.OrderId = orderId.String()
 		if err != nil {
 			orderResponse.Error = err.Error()

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -97,7 +97,7 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	}
 
 	orderBookTxsCount := pipeline.lotp.GetOrderBookTxsCount()
-	log.Info("MatchingPipeline:Run", "orderBookTxsCount", orderBookTxsCount)
+	log.Info("MatchingPipeline:Complete", "orderBookTxsCount", orderBookTxsCount)
 	if orderBookTxsCount > 0 {
 		pipeline.lotp.SetOrderBookTxsBlockNumber(blockNumber.Uint64())
 		return true

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -1272,12 +1272,11 @@ func (db *InMemoryDatabase) GetOrderValidationFields(orderId common.Hash, order 
 	asksHead := big.NewInt(0)
 	if isLongOrder && len(db.ShortOrders[marketId]) > 0 {
 		for _, _order := range db.ShortOrders[marketId] {
-			if _order.Price.Cmp(order.Price) <= 0 {
-				shouldTriggerMatching = true
-			}
 			if _order.OrderType != IOC {
 				asksHead = _order.Price
 				break
+			} else if _order.Price.Cmp(order.Price) <= 0 {
+				shouldTriggerMatching = true
 			}
 		}
 	}
@@ -1285,12 +1284,11 @@ func (db *InMemoryDatabase) GetOrderValidationFields(orderId common.Hash, order 
 	bidsHead := big.NewInt(0)
 	if len(db.LongOrders[marketId]) > 0 {
 		for _, _order := range db.LongOrders[marketId] {
-			if _order.Price.Cmp(order.Price) >= 0 {
-				shouldTriggerMatching = true
-			}
 			if _order.OrderType != IOC {
 				bidsHead = _order.Price
 				break
+			} else if _order.Price.Cmp(order.Price) >= 0 {
+				shouldTriggerMatching = true
 			}
 		}
 	}

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -378,15 +378,6 @@ func shouldRemove(acceptedBlockNumber, blockTimestamp uint64, order Order) Order
 	if expireAt.Sign() > 0 && expireAt.Int64() < int64(blockTimestamp) {
 		return REMOVE
 	}
-
-	// IOC order can not matched with any order that came after it (same block is allowed)
-	// we can only surely say about orders that came at <= acceptedBlockNumber
-	if order.OrderType == IOC {
-		if order.BlockNumber.Uint64() > acceptedBlockNumber {
-			return KEEP
-		}
-		return KEEP_IF_MATCHEABLE
-	}
 	return KEEP
 }
 

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -1315,13 +1315,26 @@ func (db *InMemoryDatabase) GetOrderValidationFields(orderId common.Hash, order 
 	}
 
 	// market data
+	// allow some grace to market orders to be filled and accept post-only orders that might fill them
+	// iterate until we find a short order that is not an IOC order.
 	asksHead := big.NewInt(0)
 	if len(db.ShortOrders[marketId]) > 0 {
-		asksHead = db.ShortOrders[marketId][0].Price
+		for _, order := range db.ShortOrders[marketId] {
+			if order.OrderType != IOC {
+				asksHead = order.Price
+				break
+			}
+		}
 	}
+
 	bidsHead := big.NewInt(0)
 	if len(db.LongOrders[marketId]) > 0 {
-		bidsHead = db.LongOrders[marketId][0].Price
+		for _, order := range db.LongOrders[marketId] {
+			if order.OrderType != IOC {
+				bidsHead = order.Price
+				break
+			}
+		}
 	}
 
 	return OrderValidationFields{

--- a/plugin/evm/orderbook/memory_database.go
+++ b/plugin/evm/orderbook/memory_database.go
@@ -1282,7 +1282,7 @@ func (db *InMemoryDatabase) GetOrderValidationFields(orderId common.Hash, order 
 	}
 
 	bidsHead := big.NewInt(0)
-	if len(db.LongOrders[marketId]) > 0 {
+	if !isLongOrder && len(db.LongOrders[marketId]) > 0 {
 		for _, _order := range db.LongOrders[marketId] {
 			if _order.OrderType != IOC {
 				bidsHead = _order.Price

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -1073,7 +1073,7 @@ func TestGetOrderValidationFields(t *testing.T) {
 				BaseOrder: hu.BaseOrder{
 					AmmIndex:          big.NewInt(0),
 					Trader:            common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
-					BaseAssetQuantity: big.NewInt(5000000000000000000),
+					BaseAssetQuantity: big.NewInt(-5000000000000000000),
 					Price:             big.NewInt(1000000000),
 					Salt:              big.NewInt(1688994806105),
 					ReduceOnly:        false,

--- a/plugin/evm/orderbook/memory_database_test.go
+++ b/plugin/evm/orderbook/memory_database_test.go
@@ -1063,3 +1063,91 @@ func TestSampleImpactPrice(t *testing.T) {
 		})
 	})
 }
+
+func TestGetOrderValidationFields(t *testing.T) {
+	db := getDatabase()
+
+	t.Run("bidsHead is unaffected by IOC orders", func(t *testing.T) {
+		signedOrder := &hu.SignedOrder{
+			LimitOrder: LimitOrder{
+				BaseOrder: hu.BaseOrder{
+					AmmIndex:          big.NewInt(0),
+					Trader:            common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
+					BaseAssetQuantity: big.NewInt(5000000000000000000),
+					Price:             big.NewInt(1000000000),
+					Salt:              big.NewInt(1688994806105),
+					ReduceOnly:        false,
+				},
+				PostOnly: true,
+			},
+			OrderType: 2,
+			ExpireAt:  big.NewInt(1688994854),
+		}
+		orderId, _ := signedOrder.Hash()
+
+		// no orders, ask and bids head should be 0
+		fields := db.GetOrderValidationFields(orderId, signedOrder)
+		assert.Equal(t, big.NewInt(0), fields.BidsHead)
+		assert.Equal(t, big.NewInt(0), fields.AsksHead)
+
+		// send a bid at $100
+		order1 := createLimitOrder(LONG, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(1), big.NewInt(100), Placed, big.NewInt(2), big.NewInt(1688994806105))
+		db.Add(&order1)
+		fields = db.GetOrderValidationFields(orderId, signedOrder)
+		assert.Equal(t, big.NewInt(100), fields.BidsHead)
+		assert.Equal(t, big.NewInt(0), fields.AsksHead)
+
+		// send a market market bid at $101
+		// assert that bidsHead remains at $101 so signed orders at (100, 101) can be accepted and matched
+		order2 := createIOCOrder(LONG, "0x22Bb736b64A0b4D4081E103f83bccF864F0404aa", big.NewInt(1e18), big.NewInt(101), Placed, big.NewInt(2), big.NewInt(2), big.NewInt(10))
+		db.Add(&order2)
+		fields = db.GetOrderValidationFields(orderId, signedOrder)
+		assert.Equal(t, big.NewInt(100), fields.BidsHead)
+		assert.Equal(t, big.NewInt(0), fields.AsksHead)
+
+		db.Delete(order1.Id)
+		db.Delete(order2.Id)
+	})
+
+	t.Run("asksHead is unaffected by IOC orders", func(t *testing.T) {
+		signedOrder := &hu.SignedOrder{
+			LimitOrder: LimitOrder{
+				BaseOrder: hu.BaseOrder{
+					AmmIndex:          big.NewInt(0),
+					Trader:            common.HexToAddress("0x70997970C51812dc3A010C7d01b50e0d17dc79C8"),
+					BaseAssetQuantity: big.NewInt(5000000000000000000),
+					Price:             big.NewInt(1000000000),
+					Salt:              big.NewInt(1688994806105),
+					ReduceOnly:        false,
+				},
+				PostOnly: true,
+			},
+			OrderType: 2,
+			ExpireAt:  big.NewInt(1688994854),
+		}
+		orderId, _ := signedOrder.Hash()
+
+		// no orders, ask and bids head should be 0
+		fields := db.GetOrderValidationFields(orderId, signedOrder)
+		assert.Equal(t, big.NewInt(0), fields.BidsHead)
+		assert.Equal(t, big.NewInt(0), fields.AsksHead)
+
+		// send a bid at $100
+		order1 := createLimitOrder(SHORT, "0x70997970C51812dc3A010C7d01b50e0d17dc79C8", big.NewInt(-1), big.NewInt(100), Placed, big.NewInt(2), big.NewInt(1688994806105))
+		db.Add(&order1)
+		fields = db.GetOrderValidationFields(orderId, signedOrder)
+		assert.Equal(t, big.NewInt(0), fields.BidsHead)
+		assert.Equal(t, big.NewInt(100), fields.AsksHead)
+
+		// send a market market bid at $101
+		// assert that bidsHead remains at $101 so signed orders at (100, 101) can be accepted and matched
+		order2 := createIOCOrder(SHORT, "0x22Bb736b64A0b4D4081E103f83bccF864F0404aa", big.NewInt(-1), big.NewInt(99), Placed, big.NewInt(2), big.NewInt(2), big.NewInt(10))
+		db.Add(&order2)
+		fields = db.GetOrderValidationFields(orderId, signedOrder)
+		assert.Equal(t, big.NewInt(0), fields.BidsHead)
+		assert.Equal(t, big.NewInt(100), fields.AsksHead)
+
+		db.Delete(order1.Id)
+		db.Delete(order2.Id)
+	})
+}


### PR DESCRIPTION
## Why this should be merged
- Allow some grace to market orders to be filled and accept post-only orders that might fill them. The post-only order will still be executed as a maker order. Think of it as a JIT liquidity concept.
- run matching engine immediately if signed order is fill-able.

## How this works
- When determining the asks/bidsHeads, we ignore the market orders on the book.
- Set `shouldTriggerMatching=true` is matcheable.

## How this was tested
- Unit test
- Local testing by placing the signed order after the market order

```
t=2024-03-07T12:47:25.895932+0530 lvl=info msg=SignedOrder/OrderAccepted               order="Order: Id: 0xfd3c6a56573bcf1e9dd34a85ea9c92a9dfefefed5750b83a860e3ec5de9a0d9b, OrderType: signed, Market: 2, PositionType: long, UserAddress: 0x70997970C51812dc3A010C7d01b50e0d17dc79C8, BaseAssetQuantity: 3, FilledBaseAssetQuantity: 0, Salt: 295357425583139074808357846432148822057, Price: 37, ReduceOnly: false, PostOnly: true, expireAt 2024-03-07 07:17:45 +0000 UTC, BlockNumber: 0" type=hubble caller=memory_database.go:422

t=2024-03-07T12:47:25.896000+0530 lvl=info msg="received new order, triggering matching pipeline" type=system caller=gossiper_orders.go:166
```
