### PR TITLE
Use latest accepted block in testing APIs

### DIFF
--- a/plugin/evm/orderbook/testing_apis.go
+++ b/plugin/evm/orderbook/testing_apis.go
@@ -76,5 +76,5 @@ func (api *TestingAPI) GetSnapshot(ctx context.Context) (Snapshot, error) {
 }
 
 func getCurrentBlockNumber(backend *eth.EthAPIBackend) uint64 {
-	return backend.CurrentHeader().Number.Uint64()
+	return backend.LastAcceptedBlock().NumberU64()
 }


### PR DESCRIPTION
## Why this should be merged

## How this works

## How this was tested

## How is this documented
