### PR TITLE
Match orders in same block as they are placed

### DIFF
--- a/.avalanche-cli.json
+++ b/.avalanche-cli.json
@@ -2,5 +2,5 @@
   "node-config": {
     "log-level": "info"
   },
-  "singlenodeenabled": false
+  "SingleNodeEnabled": false
 }

--- a/.avalanche-cli.json
+++ b/.avalanche-cli.json
@@ -1,5 +1,6 @@
 {
   "node-config": {
     "log-level": "info"
-  }
+  },
+  "singlenodeenabled": false
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -639,6 +639,22 @@ func (t *TransactionsByPriceAndNonce) Pop() {
 	heap.Pop(&t.heads)
 }
 
+func (t *TransactionsByPriceAndNonce) Copy() *TransactionsByPriceAndNonce {
+	txs := make(map[common.Address]Transactions, len(t.txs))
+	for acc, accTxs := range t.txs {
+		txs[acc] = make(Transactions, len(accTxs))
+		copy(txs[acc], accTxs)
+	}
+	heads := make(TxByPriceAndTime, len(t.heads))
+	copy(heads, t.heads)
+	return &TransactionsByPriceAndNonce{
+		txs:     txs,
+		heads:   heads,
+		signer:  t.signer,
+		baseFee: big.NewInt(0).Set(t.baseFee),
+	}
+}
+
 // copyAddressPtr copies an address.
 func copyAddressPtr(a *common.Address) *common.Address {
 	if a == nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -335,6 +335,11 @@ func (s *Ethereum) SetEtherbase(etherbase common.Address) {
 	s.miner.SetEtherbase(etherbase)
 }
 
+func (s *Ethereum) SetOrderbookChecker(orderBookChecker miner.OrderBookChecker) {
+	s.miner.SetOrderbookChecker(orderBookChecker)
+
+}
+
 func (s *Ethereum) Miner() *miner.Miner { return s.miner }
 
 func (s *Ethereum) AccountManager() *accounts.Manager { return s.accountManager }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -335,7 +335,7 @@ func (s *Ethereum) SetEtherbase(etherbase common.Address) {
 	s.miner.SetEtherbase(etherbase)
 }
 
-func (s *Ethereum) SetOrderbookChecker(orderBookChecker miner.OrderBookChecker) {
+func (s *Ethereum) SetOrderbookChecker(orderBookChecker miner.OrderbookChecker) {
 	s.miner.SetOrderbookChecker(orderBookChecker)
 
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -64,7 +64,7 @@ func (miner *Miner) SetEtherbase(addr common.Address) {
 	miner.worker.setEtherbase(addr)
 }
 
-func (miner *Miner) SetOrderbookChecker(orderBookChecker OrderBookChecker) {
+func (miner *Miner) SetOrderbookChecker(orderBookChecker OrderbookChecker) {
 	miner.worker.setOrderbookChecker(orderBookChecker)
 }
 

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -64,6 +64,10 @@ func (miner *Miner) SetEtherbase(addr common.Address) {
 	miner.worker.setEtherbase(addr)
 }
 
+func (miner *Miner) SetOrderbookChecker(orderBookChecker OrderBookChecker) {
+	miner.worker.setOrderbookChecker(orderBookChecker)
+}
+
 func (miner *Miner) GenerateBlock(predicateContext *precompileconfig.PredicateContext) (*types.Block, error) {
 	return miner.worker.commitNewWork(predicateContext)
 }

--- a/miner/orderbook_checker.go
+++ b/miner/orderbook_checker.go
@@ -1,0 +1,14 @@
+package miner
+
+import (
+	"math/big"
+
+	"github.com/ava-labs/subnet-evm/core/state"
+	"github.com/ava-labs/subnet-evm/core/types"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type OrderBookChecker interface {
+	GetMatchingTxs(tx *types.Transaction, stateDB *state.StateDB, blockNumber *big.Int) map[common.Address]types.Transactions
+	ResetMemoryDB()
+}

--- a/miner/orderbook_checker.go
+++ b/miner/orderbook_checker.go
@@ -8,7 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-type OrderBookChecker interface {
+type OrderbookChecker interface {
 	GetMatchingTxs(tx *types.Transaction, stateDB *state.StateDB, blockNumber *big.Int) map[common.Address]types.Transactions
 	ResetMemoryDB()
 }

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -100,7 +100,7 @@ type worker struct {
 	coinbase common.Address
 	clock    *mockable.Clock // Allows us mock the clock for testing
 
-	orderbookChecker OrderBookChecker
+	orderbookChecker OrderbookChecker
 }
 
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, clock *mockable.Clock) *worker {
@@ -125,7 +125,7 @@ func (w *worker) setEtherbase(addr common.Address) {
 	w.coinbase = addr
 }
 
-func (w *worker) setOrderbookChecker(orderBookChecker OrderBookChecker) {
+func (w *worker) setOrderbookChecker(orderBookChecker OrderbookChecker) {
 	w.orderbookChecker = orderBookChecker
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -99,6 +99,8 @@ type worker struct {
 	mu       sync.RWMutex   // The lock used to protect the coinbase and extra fields
 	coinbase common.Address
 	clock    *mockable.Clock // Allows us mock the clock for testing
+
+	orderbookChecker OrderBookChecker
 }
 
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, clock *mockable.Clock) *worker {
@@ -121,6 +123,10 @@ func (w *worker) setEtherbase(addr common.Address) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	w.coinbase = addr
+}
+
+func (w *worker) setOrderbookChecker(orderBookChecker OrderBookChecker) {
+	w.orderbookChecker = orderBookChecker
 }
 
 // commitNewWork generates several new sealing tasks based on the parent block.
@@ -229,14 +235,36 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 	}
 	if len(localTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, localTxs, header.BaseFee)
+		txsCopy := txs.Copy()
 		w.commitTransactions(env, txs, header.Coinbase)
+		w.commitOrderbookTxs(env, txsCopy, header)
 	}
 	if len(remoteTxs) > 0 {
 		txs := types.NewTransactionsByPriceAndNonce(env.signer, remoteTxs, header.BaseFee)
+		txsCopy := txs.Copy()
 		w.commitTransactions(env, txs, header.Coinbase)
+		w.commitOrderbookTxs(env, txsCopy, header)
 	}
 
+	w.orderbookChecker.ResetMemoryDB()
+
 	return w.commit(env)
+}
+
+func (w *worker) commitOrderbookTxs(env *environment, transactions *types.TransactionsByPriceAndNonce, header *types.Header) {
+	for {
+		tx := transactions.Peek()
+		if tx == nil {
+			break
+		}
+		transactions.Pop()
+
+		orderbookTxs := w.orderbookChecker.GetMatchingTxs(tx, env.state, header.Number)
+		if orderbookTxs != nil {
+			txsByPrice := types.NewTransactionsByPriceAndNonce(env.signer, orderbookTxs, header.BaseFee)
+			w.commitTransactions(env, txsByPrice, header.Coinbase)
+		}
+	}
 }
 
 func (w *worker) createCurrentEnvironment(predicateContext *precompileconfig.PredicateContext, parent *types.Header, header *types.Header, tstart time.Time) (*environment, error) {

--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -38,6 +38,8 @@ type LimitOrderProcesser interface {
 	GetTestingAPI() *orderbook.TestingAPI
 	GetTradingAPI() *orderbook.TradingAPI
 	RunMatchingPipeline()
+	GetMemoryDB() orderbook.LimitOrderDatabase
+	GetLimitOrderTxProcessor() orderbook.LimitOrderTxProcessor
 }
 
 type limitOrderProcesser struct {
@@ -204,6 +206,14 @@ func (lop *limitOrderProcesser) GetTradingAPI() *orderbook.TradingAPI {
 
 func (lop *limitOrderProcesser) GetTestingAPI() *orderbook.TestingAPI {
 	return orderbook.NewTestingAPI(lop.memoryDb, lop.backend, lop.configService, lop.hubbleDB)
+}
+
+func (lop *limitOrderProcesser) GetMemoryDB() orderbook.LimitOrderDatabase {
+	return lop.memoryDb
+}
+
+func (lop *limitOrderProcesser) GetLimitOrderTxProcessor() orderbook.LimitOrderTxProcessor {
+	return lop.limitOrderTxProcessor
 }
 
 func (lop *limitOrderProcesser) listenAndStoreLimitOrderTransactions() {

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -39,12 +39,27 @@ type IConfigService interface {
 
 type ConfigService struct {
 	blockChain *core.BlockChain
+	stateDB    *state.StateDB
 }
 
 func NewConfigService(blockChain *core.BlockChain) IConfigService {
 	return &ConfigService{
 		blockChain: blockChain,
 	}
+}
+
+func NewConfigServiceFromStateDB(stateDB *state.StateDB) IConfigService {
+	return &ConfigService{
+		stateDB: stateDB,
+	}
+}
+
+func (cs *ConfigService) getStateAtCurrentBlock() *state.StateDB {
+	if cs.stateDB != nil {
+		return cs.stateDB
+	}
+	stateDB, _ := cs.blockChain.StateAt(cs.blockChain.CurrentBlock().Root)
+	return stateDB
 }
 
 func (cs *ConfigService) GetAcceptableBounds(market Market) (*big.Int, *big.Int) {
@@ -77,11 +92,6 @@ func (cs *ConfigService) getMinSizeRequirement(market Market) *big.Int {
 
 func (cs *ConfigService) GetPriceMultiplier(market Market) *big.Int {
 	return bibliophile.GetMultiplier(cs.getStateAtCurrentBlock(), int64(market))
-}
-
-func (cs *ConfigService) getStateAtCurrentBlock() *state.StateDB {
-	stateDB, _ := cs.blockChain.StateAt(cs.blockChain.CurrentBlock().Root)
-	return stateDB
 }
 
 func (cs *ConfigService) GetActiveMarketsCount() int64 {

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -200,6 +200,10 @@ func (lotp *MockLimitOrderTxProcessor) GetOrderBookTxsCount() uint64 {
 	return uint64(args.Int(0))
 }
 
+func (lotp *MockLimitOrderTxProcessor) GetOrderBookTxs() map[common.Address]types.Transactions {
+	return nil
+}
+
 func (lotp *MockLimitOrderTxProcessor) ExecuteFundingPaymentTx() error {
 	return nil
 }

--- a/plugin/evm/orderbook/temp_matching.go
+++ b/plugin/evm/orderbook/temp_matching.go
@@ -1,0 +1,259 @@
+package orderbook
+
+import (
+	"encoding/json"
+	"math/big"
+
+	"github.com/ava-labs/subnet-evm/accounts/abi"
+	"github.com/ava-labs/subnet-evm/core/state"
+	"github.com/ava-labs/subnet-evm/core/types"
+	"github.com/ava-labs/subnet-evm/plugin/evm/orderbook/abis"
+	"github.com/ava-labs/subnet-evm/precompile/contracts/bibliophile"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type TempMatcher struct {
+	db                LimitOrderDatabase
+	tempDB            LimitOrderDatabase
+	lotp              LimitOrderTxProcessor
+	orderBookABI      abi.ABI
+	limitOrderBookABI abi.ABI
+	iocOrderBookABI   abi.ABI
+}
+
+func NewTempMatcher(db LimitOrderDatabase, lotp LimitOrderTxProcessor) *TempMatcher {
+	orderBookABI, err := abi.FromSolidityJson(string(abis.OrderBookAbi))
+	if err != nil {
+		panic(err)
+	}
+
+	limitOrderBookABI, err := abi.FromSolidityJson(string(abis.LimitOrderBookAbi))
+	if err != nil {
+		panic(err)
+	}
+
+	iocOrderBookABI, err := abi.FromSolidityJson(string(abis.IOCOrderBookAbi))
+	if err != nil {
+		panic(err)
+	}
+
+	return &TempMatcher{
+		db:                db,
+		lotp:              lotp,
+		orderBookABI:      orderBookABI,
+		limitOrderBookABI: limitOrderBookABI,
+		iocOrderBookABI:   iocOrderBookABI,
+	}
+}
+
+func (matcher *TempMatcher) GetMatchingTxs(tx *types.Transaction, stateDB *state.StateDB, blockNumber *big.Int) map[common.Address]types.Transactions {
+
+	to := tx.To()
+
+	if to == nil || len(tx.Data()) < 4 {
+		// tx is contract creation
+		return nil
+	}
+
+	method := tx.Data()[:4]
+	methodData := tx.Data()[4:]
+
+	var err error
+	var markets []Market
+	if matcher.tempDB == nil {
+		matcher.tempDB, err = matcher.db.GetOrderBookDataCopy()
+		if err != nil {
+			log.Error("Error in fetching tempDB", "err", err)
+			// @todo: send to metrics
+			return nil
+		}
+	}
+	switch *to {
+	case LimitOrderBookContractAddress:
+		abiMethod, err := matcher.limitOrderBookABI.MethodById(method)
+		if err != nil {
+			log.Error("Error in fetching abiMethod", "err", err)
+			return nil
+		}
+
+		// check for placeOrders and cancelOrders txs
+		switch abiMethod.Name {
+		case "placeOrders":
+			orders, err := getLimitOrdersFromMethodData(abiMethod, methodData, blockNumber)
+			if err != nil {
+				log.Error("Error in fetching orders", "err", err)
+				return nil
+			}
+			marketsMap := make(map[Market]struct{})
+			for _, order := range orders {
+				// the transaction in the args is supposed to be already committed in the db, so the status should be placed
+				status := bibliophile.GetOrderStatus(stateDB, order.Id)
+				if status != 1 { // placed
+					log.Error("GetMatchingTxs: invalid limit order status", "status", status, "order", order.Id.String())
+					// send to metrics
+					continue
+				}
+
+				matcher.tempDB.Add(order)
+				marketsMap[order.Market] = struct{}{}
+			}
+
+			markets = make([]Market, 0, len(marketsMap))
+			for market := range marketsMap {
+				markets = append(markets, market)
+			}
+
+		case "cancelOrders":
+			orders, err := getLimitOrdersFromMethodData(abiMethod, methodData, blockNumber)
+			if err != nil {
+				log.Error("Error in fetching orders", "err", err)
+				return nil
+			}
+			for _, order := range orders {
+				if err := matcher.tempDB.SetOrderStatus(order.Id, Cancelled, "", blockNumber.Uint64()); err != nil {
+					log.Error("GetMatchingTxs: error in SetOrderStatus", "method", "OrderCancelAccepted", "err", err)
+					return nil
+				}
+			}
+			// no need to run matching
+			return nil
+
+		}
+
+	case IOCOrderBookContractAddress:
+		abiMethod, err := matcher.iocOrderBookABI.MethodById(method)
+		if err != nil {
+			log.Error("Error in fetching abiMethod", "err", err)
+			return nil
+		}
+
+		switch abiMethod.Name {
+		case "placeOrders":
+			orders, err := getIOCOrdersFromMethodData(abiMethod, methodData, blockNumber)
+			if err != nil {
+				log.Error("Error in fetching orders", "err", err)
+				return nil
+			}
+			marketsMap := make(map[Market]struct{})
+			for _, order := range orders {
+				// the transaction in the args is supposed to be already committed in the db, so the status should be placed
+				status := bibliophile.IOCGetOrderStatus(stateDB, order.Id)
+				if status != 1 { // placed
+					log.Error("GetMatchingTxs: invalid ioc order status", "status", status, "order", order.Id.String())
+					// send to metrics
+					continue
+				}
+
+				matcher.tempDB.Add(order)
+				marketsMap[order.Market] = struct{}{}
+			}
+
+			markets = make([]Market, 0, len(marketsMap))
+			for market := range marketsMap {
+				markets = append(markets, market)
+			}
+		}
+	}
+
+	configService := NewConfigServiceFromStateDB(stateDB)
+	tempMatchingPipeline := NewTemporaryMatchingPipeline(matcher.tempDB, matcher.lotp, configService)
+
+	return tempMatchingPipeline.GetOrderMatchingTransactions(blockNumber, markets)
+}
+
+func (matcher *TempMatcher) ResetMemoryDB() {
+	matcher.tempDB = nil
+}
+
+func getLimitOrdersFromMethodData(abiMethod *abi.Method, methodData []byte, blockNumber *big.Int) ([]*Order, error) {
+	unpackedData, err := abiMethod.Inputs.Unpack(methodData)
+	if err != nil {
+		log.Error("Error in unpacking data", "err", err)
+		return nil, err
+	}
+
+	limitOrders := []*LimitOrder{}
+	ordersInterface := unpackedData[0]
+
+	marshalledOrders, _ := json.Marshal(ordersInterface)
+	err = json.Unmarshal(marshalledOrders, &limitOrders)
+	if err != nil {
+		log.Error("Error in unmarshalling orders", "err", err)
+		return nil, err
+	}
+
+	orders := []*Order{}
+	for _, limitOrder := range limitOrders {
+		orderId, err := limitOrder.Hash()
+		if err != nil {
+			log.Error("Error in hashing order", "err", err)
+			// @todo: send to metrics
+			return nil, err
+		}
+
+		order := &Order{
+			Id:                      orderId,
+			Market:                  Market(limitOrder.AmmIndex.Int64()),
+			PositionType:            getPositionTypeBasedOnBaseAssetQuantity(limitOrder.BaseAssetQuantity),
+			Trader:                  limitOrder.Trader,
+			BaseAssetQuantity:       limitOrder.BaseAssetQuantity,
+			FilledBaseAssetQuantity: big.NewInt(0),
+			Price:                   limitOrder.Price,
+			RawOrder:                limitOrder,
+			Salt:                    limitOrder.Salt,
+			ReduceOnly:              limitOrder.ReduceOnly,
+			BlockNumber:             blockNumber,
+			OrderType:               Limit,
+		}
+		orders = append(orders, order)
+	}
+
+	return orders, nil
+}
+
+func getIOCOrdersFromMethodData(abiMethod *abi.Method, methodData []byte, blockNumber *big.Int) ([]*Order, error) {
+	unpackedData, err := abiMethod.Inputs.Unpack(methodData)
+	if err != nil {
+		log.Error("Error in unpacking data", "err", err)
+		return nil, err
+	}
+
+	iocOrders := []*IOCOrder{}
+	ordersInterface := unpackedData[0]
+
+	marshalledOrders, _ := json.Marshal(ordersInterface)
+	err = json.Unmarshal(marshalledOrders, &iocOrders)
+	if err != nil {
+		log.Error("Error in unmarshalling orders", "err", err)
+		return nil, err
+	}
+
+	orders := []*Order{}
+	for _, iocOrder := range iocOrders {
+		orderId, err := iocOrder.Hash()
+		if err != nil {
+			log.Error("Error in hashing order", "err", err)
+			// @todo: send to metrics
+			return nil, err
+		}
+
+		order := &Order{
+			Id:                      orderId,
+			Market:                  Market(iocOrder.AmmIndex.Int64()),
+			PositionType:            getPositionTypeBasedOnBaseAssetQuantity(iocOrder.BaseAssetQuantity),
+			Trader:                  iocOrder.Trader,
+			BaseAssetQuantity:       iocOrder.BaseAssetQuantity,
+			FilledBaseAssetQuantity: big.NewInt(0),
+			Price:                   iocOrder.Price,
+			RawOrder:                iocOrder,
+			Salt:                    iocOrder.Salt,
+			ReduceOnly:              iocOrder.ReduceOnly,
+			BlockNumber:             blockNumber,
+			OrderType:               Limit,
+		}
+		orders = append(orders, order)
+	}
+
+	return orders, nil
+}

--- a/plugin/evm/orderbook/tx_processor.go
+++ b/plugin/evm/orderbook/tx_processor.go
@@ -32,6 +32,7 @@ var IOCOrderBookContractAddress = common.HexToAddress("0x03000000000000000000000
 
 type LimitOrderTxProcessor interface {
 	GetOrderBookTxsCount() uint64
+	GetOrderBookTxs() map[common.Address]types.Transactions
 	SetOrderBookTxsBlockNumber(blockNumber uint64)
 	PurgeOrderBookTxs()
 	ExecuteMatchedOrdersTx(incomingOrder Order, matchedOrder Order, fillAmount *big.Int) error
@@ -242,6 +243,10 @@ func (lotp *limitOrderTxProcessor) PurgeOrderBookTxs() {
 
 func (lotp *limitOrderTxProcessor) GetOrderBookTxsCount() uint64 {
 	return lotp.txPool.GetOrderBookTxsCount()
+}
+
+func (lotp *limitOrderTxProcessor) GetOrderBookTxs() map[common.Address]types.Transactions {
+	return lotp.txPool.GetOrderBookTxs()
 }
 
 func (lotp *limitOrderTxProcessor) SetOrderBookTxsBlockNumber(blockNumber uint64) {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -569,6 +569,8 @@ func (vm *VM) initializeChain(lastAcceptedHash common.Hash, ethConfig ethconfig.
 	vm.miner = vm.eth.Miner()
 
 	vm.limitOrderProcesser = vm.NewLimitOrderProcesser()
+	tempMatcher := orderbook.NewTempMatcher(vm.limitOrderProcesser.GetMemoryDB(), vm.limitOrderProcesser.GetLimitOrderTxProcessor())
+	vm.eth.SetOrderbookChecker(tempMatcher)
 	vm.eth.Start()
 	return vm.initChainState(vm.blockChain.LastAcceptedBlock())
 }

--- a/precompile/contracts/bibliophile/api.go
+++ b/precompile/contracts/bibliophile/api.go
@@ -182,7 +182,7 @@ type OrderDetails struct {
 func GetIOCOrdersVariables(stateDB contract.StateDB, orderHash common.Hash) VariablesReadFromIOCOrdersSlots {
 	blockPlaced := iocGetBlockPlaced(stateDB, orderHash)
 	filledAmount := iocGetOrderFilledAmount(stateDB, orderHash)
-	orderStatus := iocGetOrderStatus(stateDB, orderHash)
+	orderStatus := IOCGetOrderStatus(stateDB, orderHash)
 
 	iocExpirationCap := iocGetExpirationCap(stateDB)
 	return VariablesReadFromIOCOrdersSlots{
@@ -203,7 +203,7 @@ type VariablesReadFromOrderbookSlots struct {
 func GetOrderBookVariables(stateDB contract.StateDB, traderAddress string, senderAddress string, orderHash common.Hash) VariablesReadFromOrderbookSlots {
 	blockPlaced := getBlockPlaced(stateDB, orderHash)
 	filledAmount := getOrderFilledAmount(stateDB, orderHash)
-	orderStatus := getOrderStatus(stateDB, orderHash)
+	orderStatus := GetOrderStatus(stateDB, orderHash)
 	isTradingAuthoriy := IsTradingAuthority(stateDB, common.HexToAddress(traderAddress), common.HexToAddress(senderAddress))
 	return VariablesReadFromOrderbookSlots{
 		OrderDetails: OrderDetails{

--- a/precompile/contracts/bibliophile/client.go
+++ b/precompile/contracts/bibliophile/client.go
@@ -120,7 +120,7 @@ func (b *bibliophileClient) GetOrderFilledAmount(orderHash [32]byte) *big.Int {
 }
 
 func (b *bibliophileClient) GetOrderStatus(orderHash [32]byte) int64 {
-	return getOrderStatus(b.accessibleState.GetStateDB(), orderHash)
+	return GetOrderStatus(b.accessibleState.GetStateDB(), orderHash)
 }
 
 func (b *bibliophileClient) IOC_GetBlockPlaced(orderHash [32]byte) *big.Int {
@@ -132,7 +132,7 @@ func (b *bibliophileClient) IOC_GetOrderFilledAmount(orderHash [32]byte) *big.In
 }
 
 func (b *bibliophileClient) IOC_GetOrderStatus(orderHash [32]byte) int64 {
-	return iocGetOrderStatus(b.accessibleState.GetStateDB(), orderHash)
+	return IOCGetOrderStatus(b.accessibleState.GetStateDB(), orderHash)
 }
 
 func (b *bibliophileClient) IsTradingAuthority(trader, senderOrSigner common.Address) bool {

--- a/precompile/contracts/bibliophile/ioc_order_book.go
+++ b/precompile/contracts/bibliophile/ioc_order_book.go
@@ -27,7 +27,7 @@ func iocGetOrderFilledAmount(stateDB contract.StateDB, orderHash [32]byte) *big.
 	return fromTwosComplement(num)
 }
 
-func iocGetOrderStatus(stateDB contract.StateDB, orderHash [32]byte) int64 {
+func IOCGetOrderStatus(stateDB contract.StateDB, orderHash [32]byte) int64 {
 	orderInfo := iocOrderInfoMappingStorageSlot(orderHash)
 	return new(big.Int).SetBytes(stateDB.GetState(common.HexToAddress(IOC_ORDERBOOK_ADDRESS), common.BigToHash(new(big.Int).Add(orderInfo, big.NewInt(2)))).Bytes()).Int64()
 }

--- a/precompile/contracts/bibliophile/limit_order_book.go
+++ b/precompile/contracts/bibliophile/limit_order_book.go
@@ -22,7 +22,7 @@ func getOrderFilledAmount(stateDB contract.StateDB, orderHash [32]byte) *big.Int
 	return fromTwosComplement(num)
 }
 
-func getOrderStatus(stateDB contract.StateDB, orderHash [32]byte) int64 {
+func GetOrderStatus(stateDB contract.StateDB, orderHash [32]byte) int64 {
 	orderInfo := orderInfoMappingStorageSlot(orderHash)
 	return new(big.Int).SetBytes(stateDB.GetState(common.HexToAddress(LIMIT_ORDERBOOK_GENESIS_ADDRESS), common.BigToHash(new(big.Int).Add(orderInfo, big.NewInt(3)))).Bytes()).Int64()
 }

--- a/scripts/run_local.sh
+++ b/scripts/run_local.sh
@@ -19,7 +19,7 @@ then
     echo "31b571bf6894a248831ff937bb49f7754509fe93bbd2517c9c73c4144c0e97dc" > $FILE
 fi
 
-avalanche subnet create localnet --force --custom --genesis genesis.json --vm custom_evm.bin --config .avalanche-cli.json
+avalanche subnet create localnet --force --custom --genesis genesis.json --vm custom_evm.bin --config .avalanche-cli.json --teleporter=false
 
 # configure and add chain.json
 avalanche subnet configure localnet --chain-config chain.json --config .avalanche-cli.json


### PR DESCRIPTION
## How this works
In commitNewWork, when committing each transactions, we check whether the order(s) in the transaction match with any existing orders, and matching transactions are included in the same block.

## How this was tested
On local 
