### PR TITLE
Get fresh hubble state

### DIFF
--- a/plugin/evm/limit_order.go
+++ b/plugin/evm/limit_order.go
@@ -77,15 +77,6 @@ func NewLimitOrderProcesser(ctx *snow.Context, txPool *txpool.TxPool, shutdownCh
 	matchingPipeline := orderbook.NewMatchingPipeline(memoryDb, lotp, configService)
 	// if any of the following values are changed, the nodes will need to be restarted.
 	// This is also true for local testing. once contracts are deployed it's mandatory to restart the nodes
-	hState := &hu.HubbleState{
-		Assets:             matchingPipeline.GetCollaterals(),
-		ActiveMarkets:      matchingPipeline.GetActiveMarkets(),
-		MinAllowableMargin: configService.GetMinAllowableMargin(),
-		MaintenanceMargin:  configService.GetMaintenanceMargin(),
-		TakerFee:           configService.GetTakerFee(),
-		UpgradeVersion:     hu.V2,
-	}
-	hu.SetHubbleState(hState)
 	hu.SetChainIdAndVerifyingSignedOrdersContract(backend.ChainConfig().ChainID.Int64(), signedObAddy.String())
 
 	filterSystem := filters.NewFilterSystem(backend, filters.Config{})

--- a/plugin/evm/orderbook/config_service.go
+++ b/plugin/evm/orderbook/config_service.go
@@ -35,6 +35,8 @@ type IConfigService interface {
 	GetMarketAddressFromMarketID(marketId int64) common.Address
 	GetImpactMarginNotional(ammAddress common.Address) *big.Int
 	GetReduceOnlyAmounts(trader common.Address) []*big.Int
+
+	IsSettledAll() bool
 }
 
 type ConfigService struct {
@@ -151,4 +153,8 @@ func (cs *ConfigService) GetImpactMarginNotional(ammAddress common.Address) *big
 
 func (cs *ConfigService) GetReduceOnlyAmounts(trader common.Address) []*big.Int {
 	return bibliophile.GetReduceOnlyAmounts(cs.getStateAtCurrentBlock(), trader)
+}
+
+func (cs *ConfigService) IsSettledAll() bool {
+	return bibliophile.IsSettledAll(cs.getStateAtCurrentBlock())
 }

--- a/plugin/evm/orderbook/hubbleutils/config.go
+++ b/plugin/evm/orderbook/hubbleutils/config.go
@@ -1,35 +1,11 @@
 package hubbleutils
 
-import "math/big"
-
 var (
 	ChainId           int64
 	VerifyingContract string
-	hState            *HubbleState
 )
 
 func SetChainIdAndVerifyingSignedOrdersContract(chainId int64, verifyingContract string) {
 	ChainId = chainId
 	VerifyingContract = verifyingContract
-}
-
-func SetHubbleState(_hState *HubbleState) {
-	hState = _hState
-}
-
-func GetHubbleState() *HubbleState {
-	assets := make([]Collateral, len(hState.Assets))
-	copy(assets, hState.Assets)
-
-	activeMarkets := make([]Market, len(hState.ActiveMarkets))
-	copy(activeMarkets, hState.ActiveMarkets)
-
-	return &HubbleState{
-		Assets:             assets,
-		ActiveMarkets:      activeMarkets,
-		MinAllowableMargin: new(big.Int).Set(hState.MinAllowableMargin),
-		MaintenanceMargin:  new(big.Int).Set(hState.MaintenanceMargin),
-		TakerFee:           new(big.Int).Set(hState.TakerFee),
-		UpgradeVersion:     hState.UpgradeVersion,
-	}
 }

--- a/plugin/evm/orderbook/hubbleutils/margin_math.go
+++ b/plugin/evm/orderbook/hubbleutils/margin_math.go
@@ -65,6 +65,7 @@ func GetNotionalPositionAndMargin(hState *HubbleState, userState *UserState, mar
 	return notionalPosition, Add(margin, unrealizedPnl)
 }
 
+// SUNSET: `hState.ActiveMarkets` in the hState passed contains settled markets too
 func GetTotalNotionalPositionAndUnrealizedPnl(hState *HubbleState, userState *UserState, margin *big.Int, marginMode MarginMode) (*big.Int, *big.Int) {
 	notionalPosition := big.NewInt(0)
 	unrealizedPnl := big.NewInt(0)

--- a/plugin/evm/orderbook/liquidations.go
+++ b/plugin/evm/orderbook/liquidations.go
@@ -23,6 +23,7 @@ func (liq LiquidablePosition) GetUnfilledSize() *big.Int {
 }
 
 func calcMarginFraction(trader *Trader, hState *hu.HubbleState) *big.Int {
+	// SUNSET: this function is only used in unit tests and a test API; no need to change it
 	userState := &hu.UserState{
 		Positions:      translatePositions(trader.Positions),
 		Margins:        getMargins(trader, len(hState.Assets)),

--- a/plugin/evm/orderbook/matching_pipeline.go
+++ b/plugin/evm/orderbook/matching_pipeline.go
@@ -65,6 +65,7 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 
 	// reset ticker
 	pipeline.MatchingTicker.Reset(matchingTickerDuration)
+	// SUNSET: this is ok, we can skip matching, liquidation, settleFunding, commitSampleLiquidity when markets are settled
 	markets := pipeline.GetActiveMarkets()
 	log.Info("MatchingPipeline:Run", "blockNumber", blockNumber)
 
@@ -93,7 +94,7 @@ func (pipeline *MatchingPipeline) Run(blockNumber *big.Int) bool {
 	}
 
 	// fetch various hubble market params and run the matching engine
-	hState := hu.GetHubbleState()
+	hState := GetHubbleState(pipeline.configService)
 	hState.OraclePrices = hu.ArrayToMap(pipeline.configService.GetUnderlyingPrices())
 
 	// build trader map
@@ -123,6 +124,7 @@ func (pipeline *MatchingPipeline) GetOrderMatchingTransactions(blockNumber *big.
 	pipeline.mu.Lock()
 	defer pipeline.mu.Unlock()
 
+	// SUNSET: ok to skip when markets are settled
 	activeMarkets := pipeline.GetActiveMarkets()
 	log.Info("MatchingPipeline:GetOrderMatchingTransactions")
 
@@ -134,7 +136,7 @@ func (pipeline *MatchingPipeline) GetOrderMatchingTransactions(blockNumber *big.
 	pipeline.lotp.PurgeOrderBookTxs()
 
 	// fetch various hubble market params and run the matching engine
-	hState := hu.GetHubbleState()
+	hState := GetHubbleState(pipeline.configService)
 	hState.OraclePrices = hu.ArrayToMap(pipeline.configService.GetUnderlyingPrices())
 
 	marginMap := make(map[common.Address]*big.Int)
@@ -228,10 +230,14 @@ func (pipeline *MatchingPipeline) runLiquidations(liquidablePositions []Liquidab
 	log.Info("found positions to liquidate", "num", len(liquidablePositions))
 
 	// we need to retreive permissible bounds for liquidations in each market
+	// SUNSET: this is ok, we can skip liquidations when markets are settled
 	markets := pipeline.GetActiveMarkets()
 	type S struct {
 		Upperbound *big.Int
 		Lowerbound *big.Int
+	}
+	if len(markets) == 0 {
+		return
 	}
 	liquidationBounds := make([]S, len(markets))
 	for _, market := range markets {

--- a/plugin/evm/orderbook/mocks.go
+++ b/plugin/evm/orderbook/mocks.go
@@ -347,3 +347,7 @@ func (cs *MockConfigService) GetImpactMarginNotional(ammAddress common.Address) 
 func (cs *MockConfigService) GetReduceOnlyAmounts(trader common.Address) []*big.Int {
 	return []*big.Int{big.NewInt(0)}
 }
+
+func (cs *MockConfigService) IsSettledAll() bool {
+	return false
+}

--- a/plugin/evm/orderbook/state.go
+++ b/plugin/evm/orderbook/state.go
@@ -1,0 +1,23 @@
+package orderbook
+
+import (
+	hu "github.com/ava-labs/subnet-evm/plugin/evm/orderbook/hubbleutils"
+)
+
+func GetHubbleState(configService IConfigService) *hu.HubbleState {
+	count := configService.GetActiveMarketsCount()
+	markets := make([]Market, count)
+	for i := int64(0); i < count; i++ {
+		markets[i] = Market(i)
+	}
+	hState := &hu.HubbleState{
+		Assets:             configService.GetCollaterals(),
+		ActiveMarkets:      markets,
+		MinAllowableMargin: configService.GetMinAllowableMargin(),
+		MaintenanceMargin:  configService.GetMaintenanceMargin(),
+		TakerFee:           configService.GetTakerFee(),
+		UpgradeVersion:     hu.V2,
+	}
+
+	return hState
+}

--- a/precompile/contracts/bibliophile/clearing_house.go
+++ b/precompile/contracts/bibliophile/clearing_house.go
@@ -39,7 +39,7 @@ func marketsStorageSlot() *big.Int {
 }
 
 func GetActiveMarketsCount(stateDB contract.StateDB) int64 {
-	if isSettledAll(stateDB) {
+	if IsSettledAll(stateDB) {
 		return 0
 	}
 	return GetMarketsCountRaw(stateDB)
@@ -50,7 +50,7 @@ func GetMarketsCountRaw(stateDB contract.StateDB) int64 {
 	return new(big.Int).SetBytes(rawVal.Bytes()).Int64()
 }
 
-func isSettledAll(stateDB contract.StateDB) bool {
+func IsSettledAll(stateDB contract.StateDB) bool {
 	return stateDB.GetState(common.HexToAddress(CLEARING_HOUSE_GENESIS_ADDRESS), common.BigToHash(big.NewInt(SETTLED_ALL_SLOT))).Big().Sign() == 1
 }
 


### PR DESCRIPTION
- Get fresh hubble state, don't store it in memory. This is done to avoid restart when active markets change.
- Disable placing of signed orders
- Skip liquidations when all markets are settled